### PR TITLE
fix: createConfigurationMarker

### DIFF
--- a/plugins/de.ovgu.featureide.core/src/de/ovgu/featureide/core/internal/BuilderMarkerHandler.java
+++ b/plugins/de.ovgu.featureide.core/src/de/ovgu/featureide/core/internal/BuilderMarkerHandler.java
@@ -122,7 +122,7 @@ public class BuilderMarkerHandler implements IBuilderMarkerHandler {
 		try {
 			IMarker marker = resource.createMarker(CONFIGURATION_MARKER);
 			MarkerInfo info = ((Workspace)resource.getWorkspace()).getMarkerManager().findMarkerInfo(resource, marker.getId());
-			if (marker.exists()&& info == null) {
+			if (marker.exists() && info != null) {
 				marker.setAttribute(IMarker.MESSAGE, message);
 				marker.setAttribute(IMarker.SEVERITY, severity);
 				marker.setAttribute(IMarker.LINE_NUMBER, lineNumber);


### PR DESCRIPTION
There was a problem when trying to add markers in the configuration folder about the use of features. The markers were not added and errors were thrown to the console