### PR TITLE
fix typo & regex for valid feature names

### DIFF
--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/IFMComposerExtension.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/IFMComposerExtension.java
@@ -30,9 +30,9 @@ import org.eclipse.core.resources.IProject;
  */
 public interface IFMComposerExtension {
 
-	static final String ERROR_MESSAGE_NO_COMPOSER = "The characaters  \", (, ) are not allowed and the feature name has to be non-empty.";
-	static final String ERROR_MESSAGE_COMPOSER = "This feature name is not possible. The following regular expression descriptes all valid feature names: "
-		+ "\n   ^[a-zA-Z][a-zA-Z_0-9]*$\n\n" + ERROR_MESSAGE_NO_COMPOSER;
+	static final String ERROR_MESSAGE_NO_COMPOSER = "The characters  \", (, ) are not allowed and the feature name has to be non-empty.";
+	static final String ERROR_MESSAGE_COMPOSER = "This feature name is not possible. The following regular expression describes all valid feature names: "
+		+ "\n   ^[a-zA-Z]+\\w*$\n\n" + ERROR_MESSAGE_NO_COMPOSER;
 
 	/*
 	 * This is necessary for feature models out of a feature project.


### PR DESCRIPTION
This was not the same expression as [the one actually used](https://github.com/FeatureIDE/FeatureIDE/blob/develop/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/FMComposerExtension.java) to test validity.

```[a-zA-Z_0-9]``` does - in contrast to ```\w``` - not match ü/Ü, ä/Ä, ö/Ö etc, so german feature names were marked invalid, but accepted.

Thus, the regex here should probably be changed or replaced with description.

Also, removed two typos.