### PR TITLE
Cpath2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,31 @@
+pipeline {
+    
+    agent any
+    
+    tools {
+        maven 'Maven 3.5.2'
+    }
+
+    stages {
+        stage ('Initialize') {
+            steps {
+                sh '''
+                    echo "PATH = ${PATH}"
+                    echo "M2_HOME = ${M2_HOME}"
+                '''
+            }
+        }
+
+
+        stage ('Test') {
+            steps {
+                sh 'mvn test' 
+            }
+            post {
+                success {
+                    junit 'target/surefire-reports/**/*.xml' 
+                }
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,11 +21,6 @@ pipeline {
             steps {
                 sh 'mvn test' 
             }
-            post {
-                success {
-                    junit 'target/surefire-reports/**/*.xml' 
-                }
-            }
         }
     }
 }

--- a/tests/de.ovgu.featureide.core.ahead-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.core.ahead-test/src/de/ovgu/featureide/Commons.java
@@ -40,6 +40,8 @@ public class Commons {
 
 	private static final String TRAVIS_REMOTE_PATH = "/home/travis/build/FeatureIDE/FeatureIDE/tests/";
 
+	private static final String JENKINS_REMOTE_PATH = "/home/neapel/.jenkins/workspace/Fide/tests/";
+
 	private static final String TRAVIS_REMOTE_PATH_FORK1 = "/home/travis/build/DawidSA2017/FeatureIDE/tests/";
 
 	private static final String TRAVIS_REMOTE_PATH_FORK2 = "/home/travis/build/Henningson/FeatureIDETeam2/tests/";
@@ -59,8 +61,12 @@ public class Commons {
 					if (!folder.canRead()) {
 						folder = new File(TEAMCITY_REMOTE_PATH + PLUGIN_PATH + path);
 						if (!folder.canRead()) {
-							folder = new File(ClassLoader.getSystemResource(path).getPath());
+							folder = new File(JENKINS_REMOTE_PATH + PLUGIN_PATH + path);
+							if (!folder.canRead()) {
+								folder = new File(ClassLoader.getSystemResource(path).getPath());
+							}
 						}
+
 					}
 				}
 			}

--- a/tests/de.ovgu.featureide.core.ahead-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.core.ahead-test/src/de/ovgu/featureide/Commons.java
@@ -36,23 +36,8 @@ import de.ovgu.featureide.fm.core.io.manager.FeatureModelManager;
  */
 public class Commons {
 
-	private static final String TEAMCITY_REMOTE_PATH = "/home/itidbrun/TeamCity/buildAgent/work/featureide/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH = "/home/travis/build/FeatureIDE/FeatureIDE/tests/";
-
-	private static final String JENKINS_REMOTE_PATH = "/home/neapel/.jenkins/workspace/Fide/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK1 = "/home/travis/build/DawidSA2017/FeatureIDE/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK2 = "/home/travis/build/Henningson/FeatureIDETeam2/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK3 = "/home/travis/build/madateamprojekt/Team317/tests/";
-
-	private static final String PLUGIN_PATH = "de.ovgu.featureide.core.ahead-test/src/";
-
 	public static File getRemoteOrLocalFolder(String path) {
 		final File folder = new File("src/" + path);
-
 		return folder;
 	}
 

--- a/tests/de.ovgu.featureide.core.ahead-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.core.ahead-test/src/de/ovgu/featureide/Commons.java
@@ -51,30 +51,11 @@ public class Commons {
 	private static final String PLUGIN_PATH = "de.ovgu.featureide.core.ahead-test/src/";
 
 	public static File getRemoteOrLocalFolder(String path) {
-		File folder = new File(TRAVIS_REMOTE_PATH + PLUGIN_PATH + path);
-		if (!folder.canRead()) {
-			folder = new File(TRAVIS_REMOTE_PATH_FORK1 + PLUGIN_PATH + path);
-			if (!folder.canRead()) {
-				folder = new File(TRAVIS_REMOTE_PATH_FORK2 + PLUGIN_PATH + path);
-				if (!folder.canRead()) {
-					folder = new File(TRAVIS_REMOTE_PATH_FORK3 + PLUGIN_PATH + path);
-					if (!folder.canRead()) {
-						folder = new File(TEAMCITY_REMOTE_PATH + PLUGIN_PATH + path);
-						if (!folder.canRead()) {
-							folder = new File(JENKINS_REMOTE_PATH + PLUGIN_PATH + path);
-							if (!folder.canRead()) {
-								folder = new File(ClassLoader.getSystemResource(path).getPath());
-							}
-						}
-
-					}
-				}
-			}
-		}
+		final File folder = new File(path);
 		return folder;
 	}
 
-	private static final String TEST_CASE_PATH = "testcases/";
+	private static final String TEST_CASE_PATH = "src/testcases/";
 
 	public static File getTestCaseFolder() {
 		return getRemoteOrLocalFolder(TEST_CASE_PATH);

--- a/tests/de.ovgu.featureide.core.ahead-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.core.ahead-test/src/de/ovgu/featureide/Commons.java
@@ -51,11 +51,12 @@ public class Commons {
 	private static final String PLUGIN_PATH = "de.ovgu.featureide.core.ahead-test/src/";
 
 	public static File getRemoteOrLocalFolder(String path) {
-		final File folder = new File(path);
+		final File folder = new File("src/" + path);
+
 		return folder;
 	}
 
-	private static final String TEST_CASE_PATH = "src/testcases/";
+	private static final String TEST_CASE_PATH = "testcases/";
 
 	public static File getTestCaseFolder() {
 		return getRemoteOrLocalFolder(TEST_CASE_PATH);

--- a/tests/de.ovgu.featureide.fm.core-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.fm.core-test/src/de/ovgu/featureide/Commons.java
@@ -36,23 +36,9 @@ import de.ovgu.featureide.fm.core.io.manager.FeatureModelManager;
  */
 public class Commons {
 
-	private static final String TEAMCITY_REMOTE_PATH = "/home/itidbrun/TeamCity/buildAgent/work/featureide/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH = "/home/travis/build/FeatureIDE/FeatureIDE/tests/";
-
-	private static final String JENKINS_REMOTE_PATH = "/home/neapel/.jenkins/workspace/Fide/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK1 = "/home/travis/build/DawidSA2017/FeatureIDE/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK2 = "/home/travis/build/Henningson/FeatureIDETeam2/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK3 = "/home/travis/build/madateamprojekt/Team317/tests/";
-
-	private static final String PLUGIN_PATH = "de.ovgu.featureide.fm.core-test/src/";
 
 	public static File getRemoteOrLocalFolder(String path) {
 		final File folder = new File("src/" + path);
-
 		return folder;
 	}
 

--- a/tests/de.ovgu.featureide.fm.core-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.fm.core-test/src/de/ovgu/featureide/Commons.java
@@ -51,14 +51,14 @@ public class Commons {
 	private static final String PLUGIN_PATH = "de.ovgu.featureide.fm.core-test/src/";
 
 	public static File getRemoteOrLocalFolder(String path) {
-		final File folder = new File(path);
-		System.out.println("----------------------------" + folder.getAbsolutePath());
+		final File folder = new File("src/" + path);
+
 		return folder;
 	}
 
-	private static final String BENCHMARK_FEATURE_MODEL_PATH = "src/benchmarkFeatureModels/";
+	private static final String BENCHMARK_FEATURE_MODEL_PATH = "benchmarkFeatureModels/";
 
-	private static final String TEST_FEATURE_MODEL_PATH = "src/testFeatureModels/";
+	private static final String TEST_FEATURE_MODEL_PATH = "testFeatureModels/";;
 
 	public final static IFeatureModel loadBenchmarkFeatureModelFromFile(final String filename) {
 		return loadFeatureModelFromFile(filename, getRemoteOrLocalFolder(BENCHMARK_FEATURE_MODEL_PATH));

--- a/tests/de.ovgu.featureide.fm.core-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.fm.core-test/src/de/ovgu/featureide/Commons.java
@@ -51,32 +51,13 @@ public class Commons {
 	private static final String PLUGIN_PATH = "de.ovgu.featureide.fm.core-test/src/";
 
 	public static File getRemoteOrLocalFolder(String path) {
-		File folder = new File(TRAVIS_REMOTE_PATH + PLUGIN_PATH + path);
-		if (!folder.canRead()) {
-			folder = new File(TRAVIS_REMOTE_PATH_FORK1 + PLUGIN_PATH + path);
-			if (!folder.canRead()) {
-				folder = new File(TRAVIS_REMOTE_PATH_FORK2 + PLUGIN_PATH + path);
-				if (!folder.canRead()) {
-					folder = new File(TRAVIS_REMOTE_PATH_FORK3 + PLUGIN_PATH + path);
-					if (!folder.canRead()) {
-						folder = new File(TEAMCITY_REMOTE_PATH + PLUGIN_PATH + path);
-						if (!folder.canRead()) {
-							folder = new File(JENKINS_REMOTE_PATH + PLUGIN_PATH + path);
-							if (!folder.canRead()) {
-								folder = new File(ClassLoader.getSystemResource(path).getPath());
-							}
-						}
-
-					}
-				}
-			}
-		}
+		final File folder = new File(path);
 		return folder;
 	}
 
-	private static final String BENCHMARK_FEATURE_MODEL_PATH = "benchmarkFeatureModels/";
+	private static final String BENCHMARK_FEATURE_MODEL_PATH = "src/benchmarkFeatureModels/";
 
-	private static final String TEST_FEATURE_MODEL_PATH = "testFeatureModels/";
+	private static final String TEST_FEATURE_MODEL_PATH = "src/testFeatureModels/";
 
 	public final static IFeatureModel loadBenchmarkFeatureModelFromFile(final String filename) {
 		return loadFeatureModelFromFile(filename, getRemoteOrLocalFolder(BENCHMARK_FEATURE_MODEL_PATH));

--- a/tests/de.ovgu.featureide.fm.core-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.fm.core-test/src/de/ovgu/featureide/Commons.java
@@ -40,6 +40,8 @@ public class Commons {
 
 	private static final String TRAVIS_REMOTE_PATH = "/home/travis/build/FeatureIDE/FeatureIDE/tests/";
 
+	private static final String JENKINS_REMOTE_PATH = "/home/neapel/.jenkins/workspace/Fide/tests/";
+
 	private static final String TRAVIS_REMOTE_PATH_FORK1 = "/home/travis/build/DawidSA2017/FeatureIDE/tests/";
 
 	private static final String TRAVIS_REMOTE_PATH_FORK2 = "/home/travis/build/Henningson/FeatureIDETeam2/tests/";
@@ -59,8 +61,12 @@ public class Commons {
 					if (!folder.canRead()) {
 						folder = new File(TEAMCITY_REMOTE_PATH + PLUGIN_PATH + path);
 						if (!folder.canRead()) {
-							folder = new File(ClassLoader.getSystemResource(path).getPath());
+							folder = new File(JENKINS_REMOTE_PATH + PLUGIN_PATH + path);
+							if (!folder.canRead()) {
+								folder = new File(ClassLoader.getSystemResource(path).getPath());
+							}
 						}
+
 					}
 				}
 			}

--- a/tests/de.ovgu.featureide.fm.core-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.fm.core-test/src/de/ovgu/featureide/Commons.java
@@ -52,6 +52,7 @@ public class Commons {
 
 	public static File getRemoteOrLocalFolder(String path) {
 		final File folder = new File(path);
+		System.out.println("----------------------------" + folder.getAbsolutePath());
 		return folder;
 	}
 

--- a/tests/de.ovgu.featureide.fm.ui-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.fm.ui-test/src/de/ovgu/featureide/Commons.java
@@ -51,32 +51,13 @@ public class Commons {
 	private static final String PLUGIN_PATH = "de.ovgu.featureide.fm.ui-test/src/";
 
 	public static File getRemoteOrLocalFolder(String path) {
-		File folder = new File(TRAVIS_REMOTE_PATH + PLUGIN_PATH + path);
-		if (!folder.canRead()) {
-			folder = new File(TRAVIS_REMOTE_PATH_FORK1 + PLUGIN_PATH + path);
-			if (!folder.canRead()) {
-				folder = new File(TRAVIS_REMOTE_PATH_FORK2 + PLUGIN_PATH + path);
-				if (!folder.canRead()) {
-					folder = new File(TRAVIS_REMOTE_PATH_FORK3 + PLUGIN_PATH + path);
-					if (!folder.canRead()) {
-						folder = new File(TEAMCITY_REMOTE_PATH + PLUGIN_PATH + path);
-						if (!folder.canRead()) {
-							folder = new File(JENKINS_REMOTE_PATH + PLUGIN_PATH + path);
-							if (!folder.canRead()) {
-								folder = new File(ClassLoader.getSystemResource(path).getPath());
-							}
-						}
-
-					}
-				}
-			}
-		}
+		final File folder = new File(path);
 		return folder;
 	}
 
-	private static final String BENCHMARK_FEATURE_MODEL_PATH = "benchmarkFeatureModels/";
+	private static final String BENCHMARK_FEATURE_MODEL_PATH = "src/benchmarkFeatureModels/";
 
-	private static final String TEST_FEATURE_MODEL_PATH = "testFeatureModels/";
+	private static final String TEST_FEATURE_MODEL_PATH = "src/testFeatureModels/";
 
 	public final static IFeatureModel loadBenchmarkFeatureModelFromFile(final String filename) {
 		return loadFeatureModelFromFile(filename, getRemoteOrLocalFolder(BENCHMARK_FEATURE_MODEL_PATH));

--- a/tests/de.ovgu.featureide.fm.ui-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.fm.ui-test/src/de/ovgu/featureide/Commons.java
@@ -51,13 +51,14 @@ public class Commons {
 	private static final String PLUGIN_PATH = "de.ovgu.featureide.fm.ui-test/src/";
 
 	public static File getRemoteOrLocalFolder(String path) {
-		final File folder = new File(path);
+		final File folder = new File("src/" + path);
+
 		return folder;
 	}
 
-	private static final String BENCHMARK_FEATURE_MODEL_PATH = "src/benchmarkFeatureModels/";
+	private static final String BENCHMARK_FEATURE_MODEL_PATH = "benchmarkFeatureModels/";
 
-	private static final String TEST_FEATURE_MODEL_PATH = "src/testFeatureModels/";
+	private static final String TEST_FEATURE_MODEL_PATH = "testFeatureModels/";
 
 	public final static IFeatureModel loadBenchmarkFeatureModelFromFile(final String filename) {
 		return loadFeatureModelFromFile(filename, getRemoteOrLocalFolder(BENCHMARK_FEATURE_MODEL_PATH));

--- a/tests/de.ovgu.featureide.fm.ui-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.fm.ui-test/src/de/ovgu/featureide/Commons.java
@@ -40,6 +40,8 @@ public class Commons {
 
 	private static final String TRAVIS_REMOTE_PATH = "/home/travis/build/FeatureIDE/FeatureIDE/tests/";
 
+	private static final String JENKINS_REMOTE_PATH = "/home/neapel/.jenkins/workspace/Fide/tests/";
+
 	private static final String TRAVIS_REMOTE_PATH_FORK1 = "/home/travis/build/DawidSA2017/FeatureIDE/tests/";
 
 	private static final String TRAVIS_REMOTE_PATH_FORK2 = "/home/travis/build/Henningson/FeatureIDETeam2/tests/";
@@ -59,8 +61,12 @@ public class Commons {
 					if (!folder.canRead()) {
 						folder = new File(TEAMCITY_REMOTE_PATH + PLUGIN_PATH + path);
 						if (!folder.canRead()) {
-							folder = new File(ClassLoader.getSystemResource(path).getPath());
+							folder = new File(JENKINS_REMOTE_PATH + PLUGIN_PATH + path);
+							if (!folder.canRead()) {
+								folder = new File(ClassLoader.getSystemResource(path).getPath());
+							}
 						}
+
 					}
 				}
 			}

--- a/tests/de.ovgu.featureide.fm.ui-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.fm.ui-test/src/de/ovgu/featureide/Commons.java
@@ -36,23 +36,9 @@ import de.ovgu.featureide.fm.core.io.manager.FeatureModelManager;
  */
 public class Commons {
 
-	private static final String TEAMCITY_REMOTE_PATH = "/home/itidbrun/TeamCity/buildAgent/work/featureide/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH = "/home/travis/build/FeatureIDE/FeatureIDE/tests/";
-
-	private static final String JENKINS_REMOTE_PATH = "/home/neapel/.jenkins/workspace/Fide/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK1 = "/home/travis/build/DawidSA2017/FeatureIDE/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK2 = "/home/travis/build/Henningson/FeatureIDETeam2/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK3 = "/home/travis/build/madateamprojekt/Team317/tests/";
-
-	private static final String PLUGIN_PATH = "de.ovgu.featureide.fm.ui-test/src/";
 
 	public static File getRemoteOrLocalFolder(String path) {
 		final File folder = new File("src/" + path);
-
 		return folder;
 	}
 

--- a/tests/de.ovgu.featureide.ui-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.ui-test/src/de/ovgu/featureide/Commons.java
@@ -51,32 +51,13 @@ public class Commons {
 	private static final String PLUGIN_PATH = "de.ovgu.featureide.ui-test/src/";
 
 	public static File getRemoteOrLocalFolder(String path) {
-		File folder = new File(TRAVIS_REMOTE_PATH + PLUGIN_PATH + path);
-		if (!folder.canRead()) {
-			folder = new File(TRAVIS_REMOTE_PATH_FORK1 + PLUGIN_PATH + path);
-			if (!folder.canRead()) {
-				folder = new File(TRAVIS_REMOTE_PATH_FORK2 + PLUGIN_PATH + path);
-				if (!folder.canRead()) {
-					folder = new File(TRAVIS_REMOTE_PATH_FORK3 + PLUGIN_PATH + path);
-					if (!folder.canRead()) {
-						folder = new File(TEAMCITY_REMOTE_PATH + PLUGIN_PATH + path);
-						if (!folder.canRead()) {
-							folder = new File(JENKINS_REMOTE_PATH + PLUGIN_PATH + path);
-							if (!folder.canRead()) {
-								folder = new File(ClassLoader.getSystemResource(path).getPath());
-							}
-						}
-
-					}
-				}
-			}
-		}
+		final File folder = new File(path);
 		return folder;
 	}
 
-	private static final String FEATURE_MODEL_PATH = "models/";
+	private static final String FEATURE_MODEL_PATH = "src/models/";
 
-	private static final String STATISTICS_PATH = "statisticsfiles/";
+	private static final String STATISTICS_PATH = "src/statisticsfiles/";
 
 	public final static File getFeatureModelFolder() {
 		return getRemoteOrLocalFolder(FEATURE_MODEL_PATH);

--- a/tests/de.ovgu.featureide.ui-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.ui-test/src/de/ovgu/featureide/Commons.java
@@ -51,13 +51,14 @@ public class Commons {
 	private static final String PLUGIN_PATH = "de.ovgu.featureide.ui-test/src/";
 
 	public static File getRemoteOrLocalFolder(String path) {
-		final File folder = new File(path);
+		final File folder = new File("src/" + path);
+
 		return folder;
 	}
 
-	private static final String FEATURE_MODEL_PATH = "src/models/";
+	private static final String FEATURE_MODEL_PATH = "models/";
 
-	private static final String STATISTICS_PATH = "src/statisticsfiles/";
+	private static final String STATISTICS_PATH = "statisticsfiles/";
 
 	public final static File getFeatureModelFolder() {
 		return getRemoteOrLocalFolder(FEATURE_MODEL_PATH);

--- a/tests/de.ovgu.featureide.ui-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.ui-test/src/de/ovgu/featureide/Commons.java
@@ -40,6 +40,8 @@ public class Commons {
 
 	private static final String TRAVIS_REMOTE_PATH = "/home/travis/build/FeatureIDE/FeatureIDE/tests/";
 
+	private static final String JENKINS_REMOTE_PATH = "/home/neapel/.jenkins/workspace/Fide/tests/";
+
 	private static final String TRAVIS_REMOTE_PATH_FORK1 = "/home/travis/build/DawidSA2017/FeatureIDE/tests/";
 
 	private static final String TRAVIS_REMOTE_PATH_FORK2 = "/home/travis/build/Henningson/FeatureIDETeam2/tests/";
@@ -59,8 +61,12 @@ public class Commons {
 					if (!folder.canRead()) {
 						folder = new File(TEAMCITY_REMOTE_PATH + PLUGIN_PATH + path);
 						if (!folder.canRead()) {
-							folder = new File(ClassLoader.getSystemResource(path).getPath());
+							folder = new File(JENKINS_REMOTE_PATH + PLUGIN_PATH + path);
+							if (!folder.canRead()) {
+								folder = new File(ClassLoader.getSystemResource(path).getPath());
+							}
 						}
+
 					}
 				}
 			}

--- a/tests/de.ovgu.featureide.ui-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.ui-test/src/de/ovgu/featureide/Commons.java
@@ -36,23 +36,9 @@ import de.ovgu.featureide.fm.core.io.manager.FeatureModelManager;
  */
 public class Commons {
 
-	private static final String TEAMCITY_REMOTE_PATH = "/home/itidbrun/TeamCity/buildAgent/work/featureide/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH = "/home/travis/build/FeatureIDE/FeatureIDE/tests/";
-
-	private static final String JENKINS_REMOTE_PATH = "/home/neapel/.jenkins/workspace/Fide/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK1 = "/home/travis/build/DawidSA2017/FeatureIDE/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK2 = "/home/travis/build/Henningson/FeatureIDETeam2/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK3 = "/home/travis/build/madateamprojekt/Team317/tests/";
-
-	private static final String PLUGIN_PATH = "de.ovgu.featureide.ui-test/src/";
 
 	public static File getRemoteOrLocalFolder(String path) {
 		final File folder = new File("src/" + path);
-
 		return folder;
 	}
 


### PR DESCRIPTION
Uses the rel. path src/... inside of the 4 Common.java files in the test-packages instead of absolute paths.
Tested with success for Travis and Jenkins (generally for maven).

For a fast check (without Jenkins or Travis) open terminal in root dir. of FeatureIDE and run: 
mvn clean verify
