### PR TITLE
Rcptt gui tests maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 /plugins/de.ovgu.featureide.examples/featureide_examples/StringMatcher-FH-JML/src
 /tests/de.ovgu.featureide.fm.core-test/.featureide/
 /tests/de.ovgu.featureide.fm.core-test/feature_model_tmp**
+**/target

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 install: true
 
 script:
-- mvn clean verify
+- mvn -Pwith:gui clean verify
 
 after_failure:
 - find -name "*.txt" | grep -F 'surefire-reports' | xargs cat

--- a/gui-tests/de.ovgu.featureide.fm.gui-test/pom.xml
+++ b/gui-tests/de.ovgu.featureide.fm.gui-test/pom.xml
@@ -1,0 +1,65 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>de.ovgu.featureide</groupId>
+    <artifactId>de.ovgu.featureide</artifactId>
+    <version>3.4.0-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <artifactId>de.ovgu.featureide.fm.gui-test</artifactId>
+  <groupId>de.ovgu.featureide.fm.gui-test</groupId>
+  <version>3.4.0-SNAPSHOT</version>
+  <packaging>rcpttTest</packaging>
+
+<build>
+	
+	<plugins>
+        <plugin>
+            <groupId>org.eclipse.rcptt</groupId>
+            <artifactId>rcptt-maven-plugin</artifactId>
+            <version>2.0.1</version>
+            <extensions>true</extensions>
+            <configuration> 
+                <runner>
+                    <!-- Manage the memory used by Runner -->
+                    <vmArgs>
+                        <vmArg>-Xmx1024m</vmArg>
+                        <vmArg>-XX:MaxPermSize=256m</vmArg>
+                    </vmArgs>
+                </runner>
+                <aut>
+                  <explicit>https://ftp.fau.de/eclipse/technology/epp/downloads/release/neon/3/eclipse-rcp-neon-3-linux-gtk-x86_64.tar.gz</explicit>
+              		<injections>
+                  		<injection>
+                    		<site>file://${project.parent.basedir}/runtime/target/repository</site>
+                  		</injection>
+              		</injections>
+
+                </aut>
+                <testOptions>
+                    <execTimeout>3000</execTimeout>
+                    <testExecTimeout>3000</testExecTimeout>
+                </testOptions>      
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+
+
+
+
+<pluginRepositories> 
+    <pluginRepository>
+      <id>rcptt-snapshot</id>
+      <name>RCPTT Snapshot Repository</name>
+      <url>https://repo.eclipse.org/content/repositories/rcptt-snapshots/</url>
+    </pluginRepository>
+     <pluginRepository>
+      <id>rcptt-release</id>
+      <name>RCPTT Releases Repository </name>
+      <url>https://repo.eclipse.org/content/repositories/rcptt-releases/</url>
+    </pluginRepository> 
+</pluginRepositories>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,30 @@ mvn -Pwith:gui <phase> ...and here phase should be "package", "install" or "veri
 					</includes>
 				</configuration>
 			</plugin>
+		
+			<!--To get JaCoCo-Report run: mvn clean verify jacoco:report-->
+			<plugin>
+    			<groupId>org.jacoco</groupId>
+    			<artifactId>jacoco-maven-plugin</artifactId>
+    			<version>0.8.0</version>
+    			<executions>
+        			<execution>
+            			<id>jacoco-initialize</id>
+            			<goals>
+                			<goal>prepare-agent</goal>
+            			</goals>
+        			</execution>
+        			<execution>
+            			<id>jacoco-report</id>
+            				<phase>test</phase>
+            				<goals>
+                				<goal>report</goal>
+            				</goals>
+        			</execution>
+    				</executions>
+			</plugin>
 		</plugins>
+		
 		<pluginManagement>
 			<plugins>
 				<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,25 @@
 		<module>tests/de.ovgu.featureide.core.aspectj-test</module>
 		<module>tests/de.ovgu.featureide.core.featurehouse-test</module>
 		<module>tests/de.ovgu.featureide.core.munge-test</module>
+
+		<module>runtime</module>
 	</modules>
+
+<!--Sometimes is it usefull to skip some modules. In this case the gui-test are not set as default: if you just want to
+run the maven-lifecycle "test" it makes no sense to run gui-test too, because runtime only builds an installable version
+of FeatureIDE at lifecycle "package". However to add the module "gui-test" just run maven with: 
+mvn -Pwith:gui <phase> ...and here phase should be "package", "install" or "verify" and not "test"--> 
+	<profiles>
+        <profile>
+            <id>with:gui</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>gui-tests/de.ovgu.featureide.fm.gui-test</module>
+            </modules>
+        </profile>
+    </profiles>
 
 	<build>
 		<plugins>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -1,0 +1,213 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>de.ovgu.featureide</groupId>
+		<artifactId>de.ovgu.featureide</artifactId>
+		<version>3.4.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	<artifactId>de.ovgu.featureide.runtime</artifactId>
+	<packaging>pom</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+                <groupId>org.reficio</groupId>
+                <artifactId>p2-maven-plugin</artifactId>
+                <version>1.3.0</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <configuration>
+                            <featureDefinitions>
+                                <feature>
+
+      								<id>FeatureIDE</id>
+      								<version>3.4.0</version>
+      								<label>FeatureIDE 3.4.0 Feature</label>
+      								<providerName>A provider</providerName>
+     								<description>${project.description}</description>
+      								<copyright>A copyright</copyright>
+      								<license>A licence</license>
+
+      								<artifacts>
+                                        
+                                        <artifact>
+                                            <id>de.ovgu.featureide:br.ufal.ic.colligens:1.1.4-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+                                            <source>true</source>
+                                        </artifact>
+                                        
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                        
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.ahead:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.antenna:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                        
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.aspectj:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.conversion.ahead-featurehouse:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                        
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.featurecpp:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.featurehouse:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                        
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.framework:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.images:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                        
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.mpl:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.munge:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                        
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.munge.android:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.runtime:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                        
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.examples:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.fm.ui:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                        
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.migration:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.ui:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                        
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.ui.android:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.ui.mpl:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                        
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.fm.core:3.4.0-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                    </artifacts>
+    							
+                                </feature>
+
+  							</featureDefinitions>     
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-p2-repository-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>archive-repository</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/${project.artifactId}-${project.version}.zip</file>
+                                    <type>zip</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>			
+</project>

--- a/tests/de.ovgu.featureide.core.ahead-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.core.ahead-test/src/de/ovgu/featureide/Commons.java
@@ -36,35 +36,8 @@ import de.ovgu.featureide.fm.core.io.manager.FeatureModelManager;
  */
 public class Commons {
 
-	private static final String TEAMCITY_REMOTE_PATH = "/home/itidbrun/TeamCity/buildAgent/work/featureide/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH = "/home/travis/build/FeatureIDE/FeatureIDE/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK1 = "/home/travis/build/DawidSA2017/FeatureIDE/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK2 = "/home/travis/build/Henningson/FeatureIDETeam2/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK3 = "/home/travis/build/madateamprojekt/Team317/tests/";
-
-	private static final String PLUGIN_PATH = "de.ovgu.featureide.core.ahead-test/src/";
-
 	public static File getRemoteOrLocalFolder(String path) {
-		File folder = new File(TRAVIS_REMOTE_PATH + PLUGIN_PATH + path);
-		if (!folder.canRead()) {
-			folder = new File(TRAVIS_REMOTE_PATH_FORK1 + PLUGIN_PATH + path);
-			if (!folder.canRead()) {
-				folder = new File(TRAVIS_REMOTE_PATH_FORK2 + PLUGIN_PATH + path);
-				if (!folder.canRead()) {
-					folder = new File(TRAVIS_REMOTE_PATH_FORK3 + PLUGIN_PATH + path);
-					if (!folder.canRead()) {
-						folder = new File(TEAMCITY_REMOTE_PATH + PLUGIN_PATH + path);
-						if (!folder.canRead()) {
-							folder = new File(ClassLoader.getSystemResource(path).getPath());
-						}
-					}
-				}
-			}
-		}
+		final File folder = new File("src/" + path);
 		return folder;
 	}
 

--- a/tests/de.ovgu.featureide.fm.core-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.fm.core-test/src/de/ovgu/featureide/Commons.java
@@ -36,35 +36,8 @@ import de.ovgu.featureide.fm.core.io.manager.FeatureModelManager;
  */
 public class Commons {
 
-	private static final String TEAMCITY_REMOTE_PATH = "/home/itidbrun/TeamCity/buildAgent/work/featureide/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH = "/home/travis/build/FeatureIDE/FeatureIDE/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK1 = "/home/travis/build/DawidSA2017/FeatureIDE/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK2 = "/home/travis/build/Henningson/FeatureIDETeam2/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK3 = "/home/travis/build/madateamprojekt/Team317/tests/";
-
-	private static final String PLUGIN_PATH = "de.ovgu.featureide.fm.core-test/src/";
-
 	public static File getRemoteOrLocalFolder(String path) {
-		File folder = new File(TRAVIS_REMOTE_PATH + PLUGIN_PATH + path);
-		if (!folder.canRead()) {
-			folder = new File(TRAVIS_REMOTE_PATH_FORK1 + PLUGIN_PATH + path);
-			if (!folder.canRead()) {
-				folder = new File(TRAVIS_REMOTE_PATH_FORK2 + PLUGIN_PATH + path);
-				if (!folder.canRead()) {
-					folder = new File(TRAVIS_REMOTE_PATH_FORK3 + PLUGIN_PATH + path);
-					if (!folder.canRead()) {
-						folder = new File(TEAMCITY_REMOTE_PATH + PLUGIN_PATH + path);
-						if (!folder.canRead()) {
-							folder = new File(ClassLoader.getSystemResource(path).getPath());
-						}
-					}
-				}
-			}
-		}
+		final File folder = new File("src/" + path);
 		return folder;
 	}
 

--- a/tests/de.ovgu.featureide.fm.ui-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.fm.ui-test/src/de/ovgu/featureide/Commons.java
@@ -36,35 +36,8 @@ import de.ovgu.featureide.fm.core.io.manager.FeatureModelManager;
  */
 public class Commons {
 
-	private static final String TEAMCITY_REMOTE_PATH = "/home/itidbrun/TeamCity/buildAgent/work/featureide/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH = "/home/travis/build/FeatureIDE/FeatureIDE/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK1 = "/home/travis/build/DawidSA2017/FeatureIDE/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK2 = "/home/travis/build/Henningson/FeatureIDETeam2/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK3 = "/home/travis/build/madateamprojekt/Team317/tests/";
-
-	private static final String PLUGIN_PATH = "de.ovgu.featureide.fm.ui-test/src/";
-
 	public static File getRemoteOrLocalFolder(String path) {
-		File folder = new File(TRAVIS_REMOTE_PATH + PLUGIN_PATH + path);
-		if (!folder.canRead()) {
-			folder = new File(TRAVIS_REMOTE_PATH_FORK1 + PLUGIN_PATH + path);
-			if (!folder.canRead()) {
-				folder = new File(TRAVIS_REMOTE_PATH_FORK2 + PLUGIN_PATH + path);
-				if (!folder.canRead()) {
-					folder = new File(TRAVIS_REMOTE_PATH_FORK3 + PLUGIN_PATH + path);
-					if (!folder.canRead()) {
-						folder = new File(TEAMCITY_REMOTE_PATH + PLUGIN_PATH + path);
-						if (!folder.canRead()) {
-							folder = new File(ClassLoader.getSystemResource(path).getPath());
-						}
-					}
-				}
-			}
-		}
+		final File folder = new File("src/" + path);
 		return folder;
 	}
 

--- a/tests/de.ovgu.featureide.ui-test/src/de/ovgu/featureide/Commons.java
+++ b/tests/de.ovgu.featureide.ui-test/src/de/ovgu/featureide/Commons.java
@@ -36,35 +36,8 @@ import de.ovgu.featureide.fm.core.io.manager.FeatureModelManager;
  */
 public class Commons {
 
-	private static final String TEAMCITY_REMOTE_PATH = "/home/itidbrun/TeamCity/buildAgent/work/featureide/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH = "/home/travis/build/FeatureIDE/FeatureIDE/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK1 = "/home/travis/build/DawidSA2017/FeatureIDE/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK2 = "/home/travis/build/Henningson/FeatureIDETeam2/tests/";
-
-	private static final String TRAVIS_REMOTE_PATH_FORK3 = "/home/travis/build/madateamprojekt/Team317/tests/";
-
-	private static final String PLUGIN_PATH = "de.ovgu.featureide.ui-test/src/";
-
 	public static File getRemoteOrLocalFolder(String path) {
-		File folder = new File(TRAVIS_REMOTE_PATH + PLUGIN_PATH + path);
-		if (!folder.canRead()) {
-			folder = new File(TRAVIS_REMOTE_PATH_FORK1 + PLUGIN_PATH + path);
-			if (!folder.canRead()) {
-				folder = new File(TRAVIS_REMOTE_PATH_FORK2 + PLUGIN_PATH + path);
-				if (!folder.canRead()) {
-					folder = new File(TRAVIS_REMOTE_PATH_FORK3 + PLUGIN_PATH + path);
-					if (!folder.canRead()) {
-						folder = new File(TEAMCITY_REMOTE_PATH + PLUGIN_PATH + path);
-						if (!folder.canRead()) {
-							folder = new File(ClassLoader.getSystemResource(path).getPath());
-						}
-					}
-				}
-			}
-		}
+		final File folder = new File("src/" + path);
 		return folder;
 	}
 


### PR DESCRIPTION
**Issue: Configure Continuous Integration #605 (Gui-Tests, CodeCoverage)**
- (relative paths and adding **/target at gitignore are necessary for these subtasks of #605)
- automation of RCPTT-GuiTests
- enable JaCoCo-Coverage-Reports 
- change the maven-lifecycle at traivs from "mvn clean verify" to "mvn -Pwith:gui clean verify" to let gui-tests run at travis

_NOTE: build at travis is not stable yet (sometimes it takes 2/3 runs to pass all guitests)_