### PR TITLE
Automated gui-testing, Update-Site-Builds and Code-Coverage-Reports.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@
 /plugins/de.ovgu.featureide.examples/featureide_examples/StringMatcher-FH-JML/src
 /tests/de.ovgu.featureide.fm.core-test/.featureide/
 /tests/de.ovgu.featureide.fm.core-test/feature_model_tmp**
+**/target

--- a/gui-tests/de.ovgu.featureide.fm.gui-test/pom.xml
+++ b/gui-tests/de.ovgu.featureide.fm.gui-test/pom.xml
@@ -1,0 +1,64 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>de.ovgu.featureide</groupId>
+    <artifactId>de.ovgu.featureide</artifactId>
+    <version>3.4.3-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+  <artifactId>de.ovgu.featureide.fm.gui-test</artifactId>
+  <groupId>de.ovgu.featureide.fm.gui-test</groupId>
+  <packaging>rcpttTest</packaging>
+
+<build>
+	
+	<plugins>
+        <plugin>
+            <groupId>org.eclipse.rcptt</groupId>
+            <artifactId>rcptt-maven-plugin</artifactId>
+            <version>2.0.1</version>
+            <extensions>true</extensions>
+            <configuration> 
+                <runner>
+                    <!-- Manage the memory used by Runner -->
+                    <vmArgs>
+                        <vmArg>-Xmx1024m</vmArg>
+                        <vmArg>-XX:MaxPermSize=256m</vmArg>
+                    </vmArgs>
+                </runner>
+                <aut>
+                  <explicit>https://ftp.fau.de/eclipse/technology/epp/downloads/release/neon/3/eclipse-rcp-neon-3-linux-gtk-x86_64.tar.gz</explicit>
+              		<injections>
+                  		<injection>
+                    		<site>file://${project.parent.basedir}/runtime/target/repository</site>
+                  		</injection>
+              		</injections>
+
+                </aut>
+                <testOptions>
+                    <execTimeout>3000</execTimeout>
+                    <testExecTimeout>3000</testExecTimeout>
+                </testOptions>      
+            </configuration>
+        </plugin>
+    </plugins>
+</build>
+
+
+
+
+<pluginRepositories> 
+    <pluginRepository>
+      <id>rcptt-snapshot</id>
+      <name>RCPTT Snapshot Repository</name>
+      <url>https://repo.eclipse.org/content/repositories/rcptt-snapshots/</url>
+    </pluginRepository>
+     <pluginRepository>
+      <id>rcptt-release</id>
+      <name>RCPTT Releases Repository </name>
+      <url>https://repo.eclipse.org/content/repositories/rcptt-releases/</url>
+    </pluginRepository> 
+</pluginRepositories>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,29 @@
 		<module>tests/de.ovgu.featureide.core.munge-test</module>
 	</modules>
 
+	<!-- mvn -Pruntime -Pgui <phase> -OR- mvn -Pruntime <phase> -BUT NOT ONLY- mvn -Pgui <phase>-->
+	<profiles>
+		<profile>
+            <id>runtime</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>runtime</module>
+            </modules>
+        </profile>
+        
+        <profile>
+            <id>gui</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <modules>
+                <module>gui-tests/de.ovgu.featureide.fm.gui-test</module>
+            </modules>
+        </profile>
+    </profiles>
+
 	<build>
 		<plugins>
 			<plugin>
@@ -94,6 +117,27 @@
 						<include>**/*Tests.java</include>
 					</includes>
 				</configuration>
+			</plugin>
+
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.0</version>
+				<executions>
+					<execution>
+						<id>jacoco-initialize</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>jacoco-report</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 		<pluginManagement>
@@ -173,6 +217,24 @@
 			</plugins>
 		</pluginManagement>
 	</build>
+
+	<!-- mvn clean verify jacoco:report -->
+	<reporting>
+		<plugins>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.0</version>
+				<reportSets>
+					<reportSet>
+						<reports>
+							<report>report</report>
+						</reports>
+					</reportSet>
+				</reportSets>
+			</plugin>
+		</plugins>
+	</reporting>
 
 	<repositories>
 		<repository>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -1,0 +1,518 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>de.ovgu.featureide</groupId>
+		<artifactId>de.ovgu.featureide</artifactId>
+		<version>3.4.3-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+	<artifactId>de.ovgu.featureide.runtime</artifactId>
+	<packaging>pom</packaging>
+
+	<build>
+		<plugins>
+			<plugin>
+                <groupId>org.reficio</groupId>
+                <artifactId>p2-maven-plugin</artifactId>
+                <version>1.3.0</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <configuration>
+                            <featureDefinitions>                           	
+                            	<feature>
+                                	<id>br.ufal.ic.colligens.feature</id>
+      								<version>1.1.4-SNAPSHOT</version>
+      								<label>Colligens</label>
+      								<providerName>Ufal</providerName>
+     								<description>${description}</description>
+      								<copyright>Copyrights reserved.</copyright>
+      								<license>${license}</license>
+
+      								<artifacts>                       
+                                        <artifact>
+                                            <id>de.ovgu.featureide:br.ufal.ic.colligens:1.1.4-SNAPSHOT</id>
+                                            <transitive>false</transitive>
+                                            <source>true</source>
+                                        </artifact>
+                                    </artifacts>
+                                </feature>
+                                
+                                <feature>
+                                	<id>de.ovgu.featureide.ahead</id>
+      								<version>${project.parent.version}</version>
+      								<label>FeatureIDE extension for AHEAD (optional)</label>
+      								<providerName>University of Magdeburg</providerName>
+     								<description>Feature-oriented programming in Java with the AHEAD Tool Suite.</description>
+      								<copyright>Copyrights reserved.</copyright>
+      								<license>${license}</license>
+
+      								<artifacts>                       
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.ahead:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                    </artifacts>
+                                </feature>
+
+                                <feature>
+                                	<id>de.ovgu.featureide.antenna</id>
+      								<version>${project.parent.version}</version>
+      								<label>FeatureIDE extension for Antenna (optional)</label>
+      								<providerName>University of Magdeburg</providerName>
+     								<description>Support for the preprocessor Munge in FeatureIDE.</description>
+      								<copyright>Copyrights reserved.</copyright>
+      								<license>${license}</license>
+
+      								<artifacts>                       
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.antenna:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                    </artifacts>
+                                </feature>
+
+                                <feature>
+                                	<id>de.ovgu.featureide.aspectj</id>
+      								<version>${project.parent.version}</version>
+      								<label>FeatureIDE extension for AspectJ (optional)</label>
+      								<providerName>University of Magdeburg</providerName>
+     								<description>Enriches AspectJ with support for modeling dependencies between aspects and automatically adding/removing aspects from build path.</description>
+      								<copyright>Copyrights reserved.</copyright>
+      								<license>${license}</license>
+
+      								<artifacts>                       
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.aspectj:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                    </artifacts>
+                                </feature>
+
+                                <feature>
+                                	<id>de.ovgu.featureide.exampleprojects</id>
+      								<version>${project.parent.version}</version>
+      								<label>FeatureIDE example projects (optional)</label>
+      								<providerName>University of Magdeburg</providerName>
+     								<description>${description}</description>
+      								<copyright>Copyrights reserved.</copyright>
+      								<license>${license}</license>
+
+      								<artifacts>                       
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.examples:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                    </artifacts>
+                                </feature>
+
+                                <feature>
+                                	<id>de.ovgu.featureide.featurecpp</id>
+      								<version>${project.parent.version}</version>
+      								<label>FeatureIDE extension for FeatureC++ (optional)</label>
+      								<providerName>University of Magdeburg</providerName>
+     								<description>FeatureC++ composes C++ header files.</description>
+      								<copyright>Copyrights reserved.</copyright>
+      								<license>${license}</license>
+
+      								<artifacts>                       
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.featurecpp:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                    </artifacts>
+                                </feature>
+
+                                <feature>
+                                	<id>de.ovgu.featureide.featurehouse</id>
+      								<version>${project.parent.version}</version>
+      								<label>FeatureIDE extension for FeatureHouse (optional)</label>
+      								<providerName>University of Magdeburg</providerName>
+     								<description>FeatureHouse composes several languages, e.g., Java, XML and Python.</description>
+      								<copyright>Copyrights reserved.</copyright>
+      								<license>${license}</license>
+
+      								<artifacts>                       
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.featurehouse:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.mpl:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.ui.mpl:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.conversion.ahead-featurehouse:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                    </artifacts>
+                                </feature>
+
+                                <feature>
+                                	<id>de.ovgu.featureide.featuremodeling</id>
+      								<version>${project.parent.version}</version>
+      								<label>Feature Modeling (required)</label>
+      								<providerName>University of Magdeburg</providerName>
+     								<description>Feature modeling is part of FeatureIDE, but it can also be used separately. The plugins give you the ability to graphically model feature diagrams, to import and export them into several formats, e.g., XML, PDF, JPG, or GUIDSL. There is also an infrastructure to perform automated analysis and reasoning using SAT4J.</description>
+      								<copyright>Copyrights reserved.</copyright>
+      								<license>${license}</license>
+
+      								<artifacts>                       
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.fm.core:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.fm.ui:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                    </artifacts>
+                                </feature>
+
+                                <feature>
+                                	<id>de.ovgu.featureide.munge</id>
+      								<version>${project.parent.version}</version>
+      								<label>FeatureIDE extension for Munge (optional)</label>
+      								<providerName>University of Magdeburg</providerName>
+     								<description>Support for the preprocessor Munge in FeatureIDE.</description>
+      								<copyright>Copyrights reserved.</copyright>
+      								<license>${license}</license>
+
+      								<artifacts>                       
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.munge:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                    </artifacts>
+                                </feature>
+
+                                <feature>
+                                	<id>de.ovgu.featureide.munge.android</id>
+      								<version>${project.parent.version}</version>
+      								<label>FeatureIDE extension for Android with Munge (optional)</label>
+      								<providerName>University of Magdeburg</providerName>
+     								<description>Support for Android projects with the preprocessor Munge in FeatureIDE.</description>
+      								<copyright>Copyrights reserved.</copyright>
+      								<license>${license}</license>
+
+      								<artifacts>                       
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.ui.android:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.munge.android:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                    </artifacts>
+                                </feature>
+
+
+                                <feature>
+      								<id>de.ovgu.featureide</id>
+      								<version>${project.parent.version}</version>
+      								<label>FeatureIDE</label>
+      								<providerName>University of Magdeburg</providerName>
+     								<description>${description}</description>
+      								<copyright>Copyrights reserved.</copyright>
+      								<license>${license}</license>
+
+      								<artifacts> 
+                                    	<artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                        
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.ui:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.images:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.framework:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                        
+
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.core.runtime:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                        
+                                        <artifact>
+                                            <id>de.ovgu.featureide:de.ovgu.featureide.migration:${project.parent.version}</id>
+                                            <transitive>false</transitive>
+											<source>true</source>
+                                        </artifact>
+                                    </artifacts>
+                                </feature>
+  							</featureDefinitions>     
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
+                <groupId>org.eclipse.tycho</groupId>
+                <artifactId>tycho-p2-repository-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>archive-repository</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/${project.artifactId}-${project.version}.zip</file>
+                                    <type>zip</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+		<license url="http://www.gnu.org/licenses/lgpl.html">
+      GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. &lt;http://fsf.org/&gt;
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, &quot;this License&quot; refers to version 3 of the GNU Lesser
+General Public License, and the &quot;GNU GPL&quot; refers to version 3 of the GNU
+General Public License.
+
+  &quot;The Library&quot; refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An &quot;Application&quot; is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A &quot;Combined Work&quot; is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the &quot;Linked
+Version&quot;.
+
+  The &quot;Minimal Corresponding Source&quot; for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The &quot;Corresponding Application Code&quot; for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user&apos;s computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License &quot;or any later version&quot;
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy&apos;s public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.
+   		</license>
+
+   		<description url="http://www.fosd.de/featureide/">
+      Software program lines (SPL) have a long tradition and will gain
+momentum in the future. Today&apos;s research tries to move software
+development to a new quality of industrial production. Several
+solutions concerning different phases of the software development
+process have been proposed in order to cope with different problems
+of program family development. A major problem of program family
+engineering is still the missing tool support. The vision is
+an IDE that brings all phases of the development process together
+consistently and in a user-friendly manner. Our first version
+focuses on AHEAD, a prominent design methodology and architectural
+model for feature-based program families. 
+FeatureIDE is an Eclipse-based IDE that supports building program
+families following the AHEAD architecture model. It provides
+tools for the feature oriented design process and the implementation
+of software product lines. It integrates AHEAD tools like composition
+tools, compilers and more.
+   		</description>
+	</properties>
+</project>


### PR DESCRIPTION
Does not affect the Travis-builds/usual builds cause...
-> runtime-/guitest-builds and jacoco-reports are only executed if they are specified in the maven-lifecycle  
(like: _"mvn -Pruntime -Pgui clean verify"_   or   _"mvn clean verify jacoco:report"_)
 
1) _Automated gui-testing:_ add pom with rcptt-plugin to gui-test
2) _Update-Site-Builds:_ runtime-folder -> pom with p2-maven-plugin
3) _Code-Coverage-Reports:_ added jacoco-maven-plugin to root-pom
4) add **/target to gitignore (ignore maven output)