### PR TITLE
Fix undo-redo on "Create Feature Above"

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/operations/CreateFeatureAboveOperation.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/operations/CreateFeatureAboveOperation.java
@@ -118,6 +118,7 @@ public class CreateFeatureAboveOperation extends AbstractFeatureModelOperation {
 			}
 		} else {
 			featureModel.getStructure().replaceRoot(child.getStructure());
+			newCompound.getStructure().removeChild(child.getStructure());
 			return new FeatureIDEEvent(newCompound, EventType.FEATURE_DELETE, null, null);
 		}
 		return new FeatureIDEEvent(newCompound, EventType.FEATURE_DELETE, parent.getFeature(), null);


### PR DESCRIPTION
Fixes undo/redo when a feature is created above the root feature.
(Does not address the other rendering problem in the feature diagram editor in #802.)