### PR TITLE
Fixes getSolutions call

### DIFF
--- a/plugins/de.ovgu.featureide.fm.core/src/org/prop4j/analyses/GetSolutionAnalysis.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/org/prop4j/analyses/GetSolutionAnalysis.java
@@ -54,13 +54,13 @@ public class GetSolutionAnalysis extends AbstractAnalysis<List<int[]>> {
 	public List<int[]> analyze(IMonitor monitor) throws Exception {
 		final List<int[]> solutions = new ArrayList<>();
 		solutionLoop: for (int i = 0; i < maxSolutions; i++) {
-			final int[] model = solver.getModel();
 			switch (solver.isSatisfiable()) {
 			case TIMEOUT:
 				return Collections.emptyList();
 			case FALSE:
 				break solutionLoop;
 			case TRUE:
+				final int[] model = solver.getModel();
 				solutions.add(model);
 				if (uniqueSolutions) {
 					try {


### PR DESCRIPTION
See issue #807 for the (supposedly) bug description.

I changed the getModel invocation of the Solver instance to a line below the indirect incovation of Solver.findModel, respective `solver.isSatisfiable()`

EDIT: local tests were successful.