### PR TITLE
Fixed #957 by ordering the constraints before removal

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/operations/ElementDeleteOperation.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/operations/ElementDeleteOperation.java
@@ -133,11 +133,6 @@ public class ElementDeleteOperation extends MultiFeatureModelOperation implement
 
 		Arrays.sort(elements, new Comparator<Object>() {
 
-			// Orders Constraints descending by there appearance in featureModel.getConstraints();
-			// TODO: check if there is a better way to do this, e.g. determine the index of the constraint not
-			// when creating an DeleteConstraintOperation (the index might change till deletion), but remove the final
-			// from the attribute and set it @operation time. I would consider this more pure and can currently see no benefits
-			// of the current solution
 			@Override
 			public int compare(Object o1, Object o2) {
 				if ((o1 instanceof IConstraint) && (o2 instanceof IConstraint)) {


### PR DESCRIPTION
I consider the solution as a workaround and would like to discuss the
reasoning behind the current implementation. I cannot see a benefit from
having the constraint index stored at object instantiation rather than operation-call.