### PR TITLE
Fixed #967: Fixed that the MIG wasn`t correctly initiated before used…

### DIFF
--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/analysis/cnf/generator/configuration/twise/TWiseConfigurationGenerator.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/analysis/cnf/generator/configuration/twise/TWiseConfigurationGenerator.java
@@ -164,18 +164,16 @@ public class TWiseConfigurationGenerator extends AConfigurationGenerator impleme
 		}
 		util.setMaxSampleSize(maxSampleSize);
 		util.setRandom(getRandom());
-
+		if (!util.getCnf().getClauses().isEmpty()) {
+			util.computeMIG();
+		}
 		// TODO Variation Point: Sorting Nodes
 		presenceConditionManager = new PresenceConditionManager(util, nodes);
 		// TODO Variation Point: Building Combinations
 		combiner = new TWiseCombiner(cnf.getVariables().size());
-
 		solver.useSolutionList(0);
 		solver.setSelectionStrategy(SelectionStrategy.ORG);
 		util.computeRandomSample();
-		if (!util.getCnf().getClauses().isEmpty()) {
-			util.computeMIG();
-		}
 	}
 
 	@Override


### PR DESCRIPTION
… by the TWiseConfigurationGenerator.

The MIG now computed before used by the PresenceConditionManager, which uses the MIG internally to find dead features.