### PR TITLE
Integrate uvl

### DIFF
--- a/plugins/de.ovgu.featureide.examples/featureide_examples/UniversalVariabilityLanguage/Universal-Variability-Language-Multi/OperatingSystem.uvl
+++ b/plugins/de.ovgu.featureide.examples/featureide_examples/UniversalVariabilityLanguage/Universal-Variability-Language-Multi/OperatingSystem.uvl
@@ -1,4 +1,4 @@
-ns OperatingSystem
+namespace OperatingSystem
 
 features
 	OperatingSystem {abstract}	

--- a/plugins/de.ovgu.featureide.examples/featureide_examples/UniversalVariabilityLanguage/Universal-Variability-Language-Multi/Server.uvl
+++ b/plugins/de.ovgu.featureide.examples/featureide_examples/UniversalVariabilityLanguage/Universal-Variability-Language-Multi/Server.uvl
@@ -1,4 +1,4 @@
-ns Server
+namespace Server
 
 imports
 	OperatingSystem as os

--- a/plugins/de.ovgu.featureide.examples/featureide_examples/UniversalVariabilityLanguage/Universal-Variability-Language-Multi/submodels/FileSystem.uvl
+++ b/plugins/de.ovgu.featureide.examples/featureide_examples/UniversalVariabilityLanguage/Universal-Variability-Language-Multi/submodels/FileSystem.uvl
@@ -1,4 +1,4 @@
-ns submodels.FileSystem
+namespace submodels.FileSystem
 
 features
 	FileSystem	

--- a/plugins/de.ovgu.featureide.examples/featureide_examples/UniversalVariabilityLanguage/Universal-Variability-Language/Server.uvl
+++ b/plugins/de.ovgu.featureide.examples/featureide_examples/UniversalVariabilityLanguage/Universal-Variability-Language/Server.uvl
@@ -1,4 +1,4 @@
-ns Server
+namespace Server
 
 features
 	Server {abstract}	

--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/base/impl/MultiConstraint.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/base/impl/MultiConstraint.java
@@ -50,6 +50,10 @@ public class MultiConstraint extends Constraint {
 		this.type = type;
 	}
 
+	public boolean isFromExtern() {
+		return type != MultiFeature.TYPE_INTERN;
+	}
+
 	@Override
 	public IConstraint clone(IFeatureModel newFeatureModel) {
 		return new MultiConstraint(this, newFeatureModel);

--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
@@ -261,7 +261,7 @@ public class UVLFeatureModelFormat extends AFeatureModelFormat {
 	}
 
 	private void parseImport(MultiFeatureModel fm, Import i) {
-		fm.addInstance(i.getAlias(), i.getNamespace());
+		fm.addInstance(i.getNamespace(), i.getAlias());
 	}
 
 	/**
@@ -287,7 +287,7 @@ public class UVLFeatureModelFormat extends AFeatureModelFormat {
 			if (nsAttribute != null) {
 				namespace = nsAttribute.getValue();
 			}
-			model.setImports(mfm.getExternalModels().values().stream().map(um -> new Import(um.getVarName(), um.getModelName())).toArray(Import[]::new));
+			model.setImports(mfm.getExternalModels().values().stream().map(um -> new Import(um.getModelName(), um.getVarName())).toArray(Import[]::new));
 			if (mfm.isMultiProductLineModel()) {
 				constraints = mfm.getOwnConstraints();
 			}

--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
@@ -225,6 +225,7 @@ public class UVLFeatureModelFormat extends AFeatureModelFormat {
 				if (own) {
 					fm.addOwnConstraint(newConstraint);
 				} else {
+					newConstraint.setType(MultiFeature.TYPE_INTERFACE);
 					fm.addConstraint(newConstraint);
 				}
 			}

--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
@@ -53,6 +53,7 @@ import de.ovgu.featureide.fm.core.base.IFeatureModel;
 import de.ovgu.featureide.fm.core.base.IFeatureStructure;
 import de.ovgu.featureide.fm.core.base.impl.FMFactoryManager;
 import de.ovgu.featureide.fm.core.base.impl.MultiConstraint;
+import de.ovgu.featureide.fm.core.base.impl.MultiFeature;
 import de.ovgu.featureide.fm.core.base.impl.MultiFeatureModel;
 import de.ovgu.featureide.fm.core.base.impl.MultiFeatureModelFactory;
 import de.ovgu.featureide.fm.core.constraint.FeatureAttribute;
@@ -143,7 +144,10 @@ public class UVLFeatureModelFormat extends AFeatureModelFormat {
 
 	private IFeature parseFeature(MultiFeatureModel fm, IFeature root, Feature f) {
 		final Feature resolved = UVLParser.resolve(f, rootModel);
-		final IFeature feature = MultiFeatureModelFactory.getInstance().createFeature(fm, resolved.getName());
+		final MultiFeature feature = MultiFeatureModelFactory.getInstance().createFeature(fm, resolved.getName());
+		if (resolved.getName().contains(".")) {
+			feature.setType(MultiFeature.TYPE_INTERFACE);
+		}
 		fm.addFeature(feature);
 		if (root != null) {
 			root.getStructure().addChild(feature.getStructure());

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/AFeatureModelAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/AFeatureModelAction.java
@@ -20,8 +20,13 @@
  */
 package de.ovgu.featureide.fm.ui.editors.featuremodel.actions;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.eclipse.jface.action.Action;
 
+import de.ovgu.featureide.fm.core.base.IFeature;
+import de.ovgu.featureide.fm.core.base.impl.MultiFeature;
 import de.ovgu.featureide.fm.core.io.manager.IFeatureModelManager;
 
 /**
@@ -41,5 +46,22 @@ public abstract class AFeatureModelAction extends Action {
 	}
 
 	public void update() {}
+
+	@Override
+	public boolean isEnabled() {
+		// determine if the action has to be disabled to prevent editing imported features in other files
+		if (!(this instanceof ActionAllowedInExternalSubmodel) && getInvolvedFeatures().stream().anyMatch(f -> isExternalFeature((IFeature) f))) {
+			return false;
+		}
+		return super.isEnabled();
+	}
+
+	protected List<IFeature> getInvolvedFeatures() {
+		return Collections.emptyList();
+	}
+
+	private boolean isExternalFeature(IFeature feature) {
+		return (feature != null) && (feature instanceof MultiFeature) && ((MultiFeature) feature).isFromExtern();
+	}
 
 }

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/AbstractConstraintEditorAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/AbstractConstraintEditorAction.java
@@ -28,6 +28,7 @@ import org.eclipse.jface.viewers.SelectionChangedEvent;
 import org.eclipse.jface.viewers.TreeViewer;
 
 import de.ovgu.featureide.fm.core.base.IConstraint;
+import de.ovgu.featureide.fm.core.base.impl.MultiConstraint;
 import de.ovgu.featureide.fm.core.io.manager.IFeatureModelManager;
 import de.ovgu.featureide.fm.ui.editors.ConstraintDialog;
 
@@ -44,6 +45,7 @@ public abstract class AbstractConstraintEditorAction extends AFeatureModelAction
 	protected IStructuredSelection selection;
 
 	private final ISelectionChangedListener listener = new ISelectionChangedListener() {
+
 		@Override
 		public void selectionChanged(SelectionChangedEvent event) {
 			setSelection(event.getSelection());
@@ -74,5 +76,14 @@ public abstract class AbstractConstraintEditorAction extends AFeatureModelAction
 	}
 
 	protected abstract boolean isValidSelection(IStructuredSelection selection);
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public boolean isEnabled() {
+		if (selection.toList().stream().filter(o -> o instanceof MultiConstraint).anyMatch(c -> ((MultiConstraint) c).isFromExtern())) {
+			return false;
+		}
+		return super.isEnabled();
+	}
 
 }

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/ActionAllowedInExternalSubmodel.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/ActionAllowedInExternalSubmodel.java
@@ -1,0 +1,29 @@
+/* FeatureIDE - A Framework for Feature-Oriented Software Development
+ * Copyright (C) 2005-2020  FeatureIDE team, University of Magdeburg, Germany
+ *
+ * This file is part of FeatureIDE.
+ *
+ * FeatureIDE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * FeatureIDE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with FeatureIDE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See http://featureide.cs.ovgu.de/ for further information.
+ */
+package de.ovgu.featureide.fm.ui.editors.featuremodel.actions;
+
+/**
+ * Marker interface for actions that should be allowed even for features that are part of a submodel in an external file. An editing action should not just
+ * silently change other files than the open one, as it could make other models invalid.
+ *
+ * @author Dominik Engelhardt
+ */
+public interface ActionAllowedInExternalSubmodel {}

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/CalculateDependencyAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/CalculateDependencyAction.java
@@ -46,7 +46,7 @@ import de.ovgu.featureide.fm.ui.wizards.SubtreeDependencyWizard;
  *
  * @author Ananieva Sofia
  */
-public class CalculateDependencyAction extends SingleSelectionAction {
+public class CalculateDependencyAction extends SingleSelectionAction implements ActionAllowedInExternalSubmodel {
 
 	private static final JobToken calculateDependencyToken = LongRunningWrapper.createToken(JobStartingStrategy.CANCEL_WAIT_ONE);
 

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/CollapseSiblingsAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/CollapseSiblingsAction.java
@@ -39,7 +39,7 @@ import de.ovgu.featureide.fm.ui.editors.featuremodel.operations.SetSiblingsToCol
  *
  * @author Maximilian Kühl
  */
-public class CollapseSiblingsAction extends SingleSelectionAction {
+public class CollapseSiblingsAction extends SingleSelectionAction implements ActionAllowedInExternalSubmodel {
 
 	public static final String ID = "de.ovgu.featureide.collapsefeatures";
 

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/CreateConstraintAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/CreateConstraintAction.java
@@ -36,7 +36,7 @@ import de.ovgu.featureide.fm.core.io.manager.IFeatureModelManager;
  * @author Thomas Thuem
  * @author Marcus Pinnecke (Feature Interface)
  */
-public class CreateConstraintAction extends AbstractConstraintEditorAction {
+public class CreateConstraintAction extends AbstractConstraintEditorAction implements ActionAllowedInExternalSubmodel {
 
 	public static final String ID = "de.ovgu.featureide.createconstraint";
 

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/DeleteAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/DeleteAction.java
@@ -22,6 +22,8 @@ package de.ovgu.featureide.fm.ui.editors.featuremodel.actions;
 
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.gef.ui.parts.GraphicalViewerImpl;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -118,5 +120,10 @@ public class DeleteAction extends AFeatureModelAction {
 		}
 
 		return true;
+	}
+
+	@Override
+	protected List<IFeature> getInvolvedFeatures() {
+		return ElementDeleteOperation.getFeatureNames(viewer).stream().map(f -> featureModelManager.getObject().getFeature(f)).collect(Collectors.toList());
 	}
 }

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/MultipleSelectionAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/MultipleSelectionAction.java
@@ -22,6 +22,7 @@ package de.ovgu.featureide.fm.ui.editors.featuremodel.actions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.eclipse.gef.ui.parts.AbstractEditPartViewer;
 import org.eclipse.gef.ui.parts.GraphicalViewerImpl;
@@ -189,6 +190,11 @@ public abstract class MultipleSelectionAction extends AFeatureModelAction implem
 			|| EventType.FEATURE_COLLAPSED_CHANGED.equals(prop)) {
 			updateProperties();
 		}
+	}
+
+	@Override
+	protected List<IFeature> getInvolvedFeatures() {
+		return getSelectedFeatures().stream().map(f -> featureModelManager.getObject().getFeature(f)).collect(Collectors.toList());
 	}
 
 }

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/SelectSubtreeAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/SelectSubtreeAction.java
@@ -40,7 +40,7 @@ import de.ovgu.featureide.fm.ui.editors.featuremodel.editparts.FeatureEditPart;
  * @author Sabrina Hugo
  * @author Christian Orsinger
  */
-public class SelectSubtreeAction extends SingleSelectionAction {
+public class SelectSubtreeAction extends SingleSelectionAction implements ActionAllowedInExternalSubmodel {
 
 	public static final String ID = "de.ovgu.featureide.selectSubtree";
 	private static ImageDescriptor createImage;

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/SingleSelectionAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/SingleSelectionAction.java
@@ -20,6 +20,9 @@
  */
 package de.ovgu.featureide.fm.ui.editors.featuremodel.actions;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.eclipse.gef.ui.parts.AbstractEditPartViewer;
 import org.eclipse.gef.ui.parts.GraphicalViewerImpl;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -153,6 +156,11 @@ public abstract class SingleSelectionAction extends AFeatureModelAction implemen
 		default:
 			break;
 		}
+	}
+
+	@Override
+	protected List<IFeature> getInvolvedFeatures() {
+		return Collections.singletonList(feature);
 	}
 
 }

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/operations/ElementDeleteOperation.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/operations/ElementDeleteOperation.java
@@ -88,7 +88,7 @@ public class ElementDeleteOperation extends MultiFeatureModelOperation implement
 		return ID;
 	}
 
-	private static List<String> getFeatureNames(Object viewer) {
+	public static List<String> getFeatureNames(Object viewer) {
 		final IStructuredSelection selection;
 		if (viewer instanceof GraphicalViewerImpl) {
 			selection = (IStructuredSelection) ((GraphicalViewerImpl) viewer).getSelection();

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/actions/FocusOnExplanationInViewAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/actions/FocusOnExplanationInViewAction.java
@@ -37,6 +37,7 @@ import de.ovgu.featureide.fm.core.io.manager.IFeatureModelManager;
 import de.ovgu.featureide.fm.ui.FMUIPlugin;
 import de.ovgu.featureide.fm.ui.editors.IGraphicalFeatureModel;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.actions.AbstractConstraintEditorAction;
+import de.ovgu.featureide.fm.ui.editors.featuremodel.actions.ActionAllowedInExternalSubmodel;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.operations.FeatureModelOperationWrapper;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.operations.FocusOnExplanationOperation;
 
@@ -45,7 +46,7 @@ import de.ovgu.featureide.fm.ui.editors.featuremodel.operations.FocusOnExplanati
  *
  * @author Rahel Arens
  */
-public class FocusOnExplanationInViewAction extends AbstractConstraintEditorAction {
+public class FocusOnExplanationInViewAction extends AbstractConstraintEditorAction implements ActionAllowedInExternalSubmodel {
 
 	public static final String ID = "de.ovgu.featureide.focusonexplanationinview";
 

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/listener/ConstraintViewKeyListener.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/listener/ConstraintViewKeyListener.java
@@ -22,6 +22,7 @@ package de.ovgu.featureide.fm.ui.views.constraintview.listener;
 
 import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.core.commands.operations.IUndoContext;
+import org.eclipse.jface.action.Action;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.KeyListener;
@@ -37,6 +38,7 @@ import de.ovgu.featureide.fm.ui.views.constraintview.view.ConstraintView;
  * @author Rosiak Kamil
  */
 public class ConstraintViewKeyListener implements KeyListener {
+
 	// integer values that are returned when pressing a special button (from keyListener)
 	private final int F_BUTTON_PRESSED = 102;
 	private final int Z_BUTTON_PRESSED = 122;
@@ -53,7 +55,10 @@ public class ConstraintViewKeyListener implements KeyListener {
 	public void keyPressed(KeyEvent e) {
 		if (e.keyCode == SWT.DEL) {
 			// pressing the del button while having a constraint selected will delete it
-			new DeleteConstraintInViewAction(viewer.getViewer(), controller.getFeatureModelManager()).run();
+			final Action deleteAction = new DeleteConstraintInViewAction(viewer.getViewer(), controller.getFeatureModelManager());
+			if (deleteAction.isEnabled()) {
+				deleteAction.run();
+			}
 		} else if (((e.stateMask == (SWT.CTRL)) && (e.keyCode == F_BUTTON_PRESSED))) {
 			// pressing CTRL + F will get you in the search box
 			viewer.getSearchBox().setFocus();


### PR DESCRIPTION
Regarding which actions should be available for imported features, there is no clear criterion in the hierarchy and no top-level abstract way to determine it at runtime.
Current solution is to check in `AFeatureModelAction` for external features. Relevant subclasses provide the involved features for this check with `getInvolvedFeatures()`. Exceptions are marked with the marker interface `ActionAllowedInExternalSubmodel`.
```
AFeatureModelAction                     overrides isEnabled(), looking for external features.
├── AbstractConstraintEditorAction      overrides isEnabled(), looking for external constraints.
│   ├── CreateConstraintAction          marked as exception with marker interface
│   │   └── CreateConstraintWithAction  marked as exception through parent
│   ├── DeleteConstraintInViewAction
│   ├── EditConstraintAction
│   ├── EditConstraintInViewAction
│   └── FocusOnExplanationInViewAction  marked as exception with marker interface
├── AdjustModelToEditorSizeAction
├── AutomatedCalculationsAction
├── ConstrainsCalculationsAction
├── DeleteAction                        implements getInvolvedFeatures() for deletion
├── FeaturesOnlyCalculationAction
├── MultipleSelectionAction             implements getInvolvedFeatures() for multiple selection
│   ├── AbstractAction
│   ├── CollapseAction                  marked as exception with marker interface
│   ├── HiddenAction
│   └── MandatoryAction
├── RunManualCalculationsAction
└── SingleSelectionAction               implements getInvolvedFeatures() for single selection
    ├── AlternativeAction
    ├── AndAction
    ├── CalculateDependencyAction       marked as exception with marker interface
    ├── ChangeFeatureDescriptionAction
    ├── CollapseSiblingsAction          marked as exception with marker interface
    ├── CreateFeatureBelowAction
    ├── CreateSiblingAction
    ├── OrAction
    ├── RenameAction
    └── SelectSubtreeAction             marked as exception with marker interface
```
