### PR TITLE
Fixed #1053

### DIFF
--- a/plugins/de.ovgu.featureide.core/src/de/ovgu/featureide/core/internal/FeatureProject.java
+++ b/plugins/de.ovgu.featureide.core/src/de/ovgu/featureide/core/internal/FeatureProject.java
@@ -1628,10 +1628,12 @@ public class FeatureProject extends BuilderMarkerHandler implements IFeatureProj
 				modelFile.createModelMarker(THE_FEATURE_MODEL_IS_VOID_COMMA__I_E__COMMA__IT_CONTAINS_NO_PRODUCTS, IMarker.SEVERITY_ERROR, 0);
 			}
 		}
-		try {
-			createAndDeleteFeatureFolders();
-		} catch (final CoreException e) {
-			LOGGER.logError(e);
+		if (composerExtension.createFolderForFeatures()) {
+			try {
+				createAndDeleteFeatureFolders();
+			} catch (final CoreException e) {
+				LOGGER.logError(e);
+			}
 		}
 	}
 


### PR DESCRIPTION
Empty folders were deleted, because they were treated as empty feature folders with no corresponding feature. Despite Antenna not using feature folders. Now createAndDeleteFeatureFolders() is only called for composers that actually use feature folders.