### PR TITLE
As unselectable features are not displayed in gray correcly on Ubuntu, show them additionally in italics

### DIFF
--- a/plugins/de.ovgu.featureide.fm.core/library/README.md
+++ b/plugins/de.ovgu.featureide.fm.core/library/README.md
@@ -12,7 +12,9 @@
 
 ### Build
 - Go to the folder `library` of the fm.core plug-in  
-`cd plugins/de.ovgu.featureide.fm.core/library`
+`cd plugins/de.ovgu.featureide.fm.core/library`  
+- If you want to use a custom JDK create a file named `build_jar.properties` with the following content:  
+`bin.javac.path=<path-to-your-javac>`  
 - Compile the source
   - **Using the command line:**
     - Run *ant* with the target *build* (or *clean_build*)  

--- a/plugins/de.ovgu.featureide.fm.core/library/subant_build_jar.xml
+++ b/plugins/de.ovgu.featureide.fm.core/library/subant_build_jar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project name="JAR Build Script" default="build" basedir=".">
-
+	
 	<!-- Set JAR name -->
 	<property name="build.jar.version" value="3.7.0" />
 	<property name="build.jar.name" value="de.ovgu.featureide.lib.fm" />
@@ -22,6 +22,12 @@
 
 	<condition property="exist-custom-properties">
 		<available file="build_jar.properties" />
+	</condition>
+	
+	<condition property="not-exist-custom-properties">
+	    <not>
+			<available file="build_jar.properties" />
+	    </not>
 	</condition>
 
 	<target name="load-custom-properties" if="exist-custom-properties">
@@ -62,16 +68,9 @@
 		</pathconvert>
 		
 		<!-- Compile the src folder -->
-		<javac
-			srcdir="${src.dir}"
-			destdir="${build.bin.dir}"
-			classpathref="classpath"
-			excludesfile="${build.excludes.path}"
-			debug="on" includeantruntime="false" fork="yes"
-			source="1.8" target="1.8">
-			<compilerarg value="-Xlint" />
-		</javac>
-
+		<antcall target="custom-javac" />
+		<antcall target="default-javac" />
+		
 		<!-- Calculate checksum for .class files -->
 		<checksum algorithm="SHA-256" totalproperty="build.checksum" forceoverwrite="yes">
 			<fileset dir="${build.bin.dir}">
@@ -87,7 +86,39 @@
 
 		<!-- Create version file -->
 		<echo file="${build.version.path}" append="false">FeatureIDE Version:	${build.jar.version}${line.separator}Build Time:         ${timeStamp}${line.separator}Checksum (SHA-256): ${build.checksum}${line.separator}</echo>
-
+	</target>
+	
+	<target name="default-javac" if="not-exist-custom-properties">
+    	<echo>Using default JDK</echo>
+		<path id="classpath">
+			<fileset dir="${lib.dir}" includes="*.jar" />
+		</path>
+		<javac
+			srcdir="${src.dir}"
+			destdir="${build.bin.dir}"
+			classpathref="classpath"
+			excludesfile="${build.excludes.path}"
+			debug="on" includeantruntime="false" fork="yes"
+			source="1.8" target="1.8">
+			<compilerarg value="-Xlint" />
+		</javac>
+	</target>
+	
+	<target name="custom-javac" if="exist-custom-properties">
+    	<echo>Using custom JDK: ${bin.javac.path}</echo>
+		<path id="classpath">
+			<fileset dir="${lib.dir}" includes="*.jar" />
+		</path>
+		<javac
+			srcdir="${src.dir}"
+			destdir="${build.bin.dir}"
+			classpathref="classpath"
+			excludesfile="${build.excludes.path}"
+			debug="on" includeantruntime="false" fork="yes"
+			source="1.8" target="1.8"
+			executable="${bin.javac.path}">
+			<compilerarg value="-Xlint" />
+		</javac>
 	</target>
 
 	<!-- Build jar file, including source files and license file -->

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/configuration/ConfigurationTreeEditorPage.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/configuration/ConfigurationTreeEditorPage.java
@@ -964,6 +964,8 @@ public abstract class ConfigurationTreeEditorPage extends EditorPart implements 
 						checked = false;
 						grayed = true;
 						fgColor = gray;
+						// On most operating systems, we use gray text color to show that a feature cannot be selected.
+						// On Ubuntu, this does not work and instead, we use an italic font (see issue #1055).
 						font = treeItemItalicFont;
 						break;
 					case UNDEFINED:
@@ -975,6 +977,7 @@ public abstract class ConfigurationTreeEditorPage extends EditorPart implements 
 					if (automatic == Selection.UNDEFINED) {
 						switch (recommended) {
 						case SELECTED:
+							// again, this is a workaround for Ubuntu, which does not show the gray font color correctly
 							font = fgColor == gray ? treeItemBoldItalicFont : treeItemBoldFont;
 							fgColor = green;
 							break;

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/configuration/ConfigurationTreeEditorPage.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/configuration/ConfigurationTreeEditorPage.java
@@ -164,7 +164,9 @@ public abstract class ConfigurationTreeEditorPage extends EditorPart implements 
 	protected static final Color red = new Color(null, 240, 0, 0);
 
 	protected static final Font treeItemStandardFont = new Font(null, ARIAL, 8, SWT.NORMAL);
-	protected static final Font treeItemSpecialFont = new Font(null, ARIAL, 8, SWT.BOLD);
+	protected static final Font treeItemBoldFont = new Font(null, ARIAL, 8, SWT.BOLD);
+	protected static final Font treeItemItalicFont = new Font(null, ARIAL, 8, SWT.ITALIC);
+	protected static final Font treeItemBoldItalicFont = new Font(null, ARIAL, 8, SWT.BOLD | SWT.ITALIC);
 
 	private static final Image IMAGE_EXPAND = FMUIPlugin.getDefault().getImageDescriptor("icons/expand.gif").createImage();
 	private static final Image IMAGE_COLLAPSE = FMUIPlugin.getDefault().getImageDescriptor("icons/collapse.gif").createImage();
@@ -962,6 +964,7 @@ public abstract class ConfigurationTreeEditorPage extends EditorPart implements 
 						checked = false;
 						grayed = true;
 						fgColor = gray;
+						font = treeItemItalicFont;
 						break;
 					case UNDEFINED:
 						checked = feature.getManual() == Selection.SELECTED;
@@ -972,11 +975,11 @@ public abstract class ConfigurationTreeEditorPage extends EditorPart implements 
 					if (automatic == Selection.UNDEFINED) {
 						switch (recommended) {
 						case SELECTED:
-							font = treeItemSpecialFont;
+							font = fgColor == gray ? treeItemBoldItalicFont : treeItemBoldFont;
 							fgColor = green;
 							break;
 						case UNSELECTED:
-							font = treeItemSpecialFont;
+							font = fgColor == gray ? treeItemBoldItalicFont : treeItemBoldFont;
 							fgColor = blue;
 							break;
 						case UNDEFINED:


### PR DESCRIPTION
See the discussion in issue #1055.