### PR TITLE
Fixes 1093

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/ConstraintViewController.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/ConstraintViewController.java
@@ -254,7 +254,6 @@ public class ConstraintViewController extends ViewPart implements GUIDefaults {
 	 * a FeatureDiagram" text is shown.
 	 */
 	public void refresh() {
-		System.err.println("REFRESH CALLED");
 		final boolean constraintsViewVisible = isConstraintsViewVisible();
 		final boolean constraintsListVisible = isConstraintsListVisible();
 
@@ -315,7 +314,7 @@ public class ConstraintViewController extends ViewPart implements GUIDefaults {
 			final Boolean isAutomaticCalculation =
 				FeatureModelProperty.getBooleanProperty(newFeatureModelEditor.getFeatureModelManager().getSnapshot().getProperty(),
 						FeatureModelProperty.TYPE_CALCULATIONS, FeatureModelProperty.PROPERTY_CALCULATIONS_RUN_AUTOMATICALLY);
-			if ((isAutomaticCalculation != null) && isAutomaticCalculation) {
+			if (isAutomaticCalculation == Boolean.TRUE) {
 				analyzer = newFeatureModelEditor.getFeatureModelManager().getVariableFormula().getAnalyzer();
 			}
 

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/ConstraintViewController.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/ConstraintViewController.java
@@ -40,11 +40,13 @@ import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.ViewPart;
 
 import de.ovgu.featureide.fm.core.AnalysesCollection;
+import de.ovgu.featureide.fm.core.FeatureModelAnalyzer;
 import de.ovgu.featureide.fm.core.analysis.cnf.formula.FeatureModelFormula;
 import de.ovgu.featureide.fm.core.base.IConstraint;
 import de.ovgu.featureide.fm.core.base.IFeatureModel;
 import de.ovgu.featureide.fm.core.base.event.FeatureIDEEvent;
 import de.ovgu.featureide.fm.core.base.event.IEventListener;
+import de.ovgu.featureide.fm.core.base.impl.FeatureModelProperty;
 import de.ovgu.featureide.fm.core.io.manager.FeatureModelManager;
 import de.ovgu.featureide.fm.core.localization.StringTable;
 import de.ovgu.featureide.fm.ui.FMUIPlugin;
@@ -81,6 +83,8 @@ public class ConstraintViewController extends ViewPart implements GUIDefaults {
 
 	private FeatureModelEditor featureModelEditor;
 	private boolean featureDiagramPageVisible = false;
+
+	private FeatureModelAnalyzer analyzer;
 
 	/**
 	 * The constraint used to detect when the analysis is finished
@@ -250,6 +254,7 @@ public class ConstraintViewController extends ViewPart implements GUIDefaults {
 	 * a FeatureDiagram" text is shown.
 	 */
 	public void refresh() {
+		System.err.println("REFRESH CALLED");
 		final boolean constraintsViewVisible = isConstraintsViewVisible();
 		final boolean constraintsListVisible = isConstraintsListVisible();
 
@@ -307,6 +312,13 @@ public class ConstraintViewController extends ViewPart implements GUIDefaults {
 
 		// add listeners, etc. to new FeatureModelEditor
 		if (newFeatureModelEditor != null) {
+			final Boolean isAutomaticCalculation =
+				FeatureModelProperty.getBooleanProperty(newFeatureModelEditor.getFeatureModelManager().getSnapshot().getProperty(),
+						FeatureModelProperty.TYPE_CALCULATIONS, FeatureModelProperty.PROPERTY_CALCULATIONS_RUN_AUTOMATICALLY);
+			if ((isAutomaticCalculation != null) && isAutomaticCalculation) {
+				analyzer = newFeatureModelEditor.getFeatureModelManager().getVariableFormula().getAnalyzer();
+			}
+
 			newFeatureModelEditor.diagramEditor.addSelectionChangedListener(selectionListener);
 			newFeatureModelEditor.addPageChangedListener(pageChangeListener);
 			newFeatureModelEditor.addEventListener(eventListener);
@@ -439,4 +451,7 @@ public class ConstraintViewController extends ViewPart implements GUIDefaults {
 		return featureModelEditor;
 	}
 
+	public FeatureModelAnalyzer getAnalyzer() {
+		return analyzer;
+	}
 }

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/content/ConstraintViewConstraintColumnLabelProvider.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/content/ConstraintViewConstraintColumnLabelProvider.java
@@ -10,6 +10,7 @@ import org.eclipse.swt.widgets.Display;
 import de.ovgu.featureide.fm.core.analysis.ConstraintProperties;
 import de.ovgu.featureide.fm.core.base.IConstraint;
 import de.ovgu.featureide.fm.core.base.IFeatureModelElement;
+import de.ovgu.featureide.fm.core.base.impl.FeatureModelProperty;
 import de.ovgu.featureide.fm.core.editing.FeatureModelToNodeTraceModel;
 import de.ovgu.featureide.fm.core.explanations.Reason;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.GUIDefaults;
@@ -105,12 +106,15 @@ public class ConstraintViewConstraintColumnLabelProvider extends ColumnLabelProv
 				return getColoredCircleImage(color);
 			}
 
-			final ConstraintProperties constraintProperties =
-				controller.getFeatureModelManager().getVariableFormula().getAnalyzer().getAnalysesCollection().getConstraintProperty(constraint);
-			if (constraintProperties.hasStatus(ConstraintProperties.ConstraintStatus.REDUNDANT)) {
-				return GUIDefaults.FM_INFO;
-			}
+			final Boolean isAutomaticCalculation = FeatureModelProperty.getBooleanProperty(controller.getFeatureModelManager().getSnapshot().getProperty(),
+					FeatureModelProperty.TYPE_CALCULATIONS, FeatureModelProperty.PROPERTY_CALCULATIONS_RUN_AUTOMATICALLY);
+			if ((isAutomaticCalculation != null) && isAutomaticCalculation) {
 
+				final ConstraintProperties constraintProperties = controller.getAnalyzer().getAnalysesCollection().getConstraintProperty(constraint);
+				if (constraintProperties.hasStatus(ConstraintProperties.ConstraintStatus.REDUNDANT)) {
+					return GUIDefaults.FM_INFO;
+				}
+			}
 			return null;
 		}
 	}

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/content/ConstraintViewConstraintColumnLabelProvider.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/content/ConstraintViewConstraintColumnLabelProvider.java
@@ -7,6 +7,7 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.widgets.Display;
 
+import de.ovgu.featureide.fm.core.FeatureModelAnalyzer;
 import de.ovgu.featureide.fm.core.analysis.ConstraintProperties;
 import de.ovgu.featureide.fm.core.base.IConstraint;
 import de.ovgu.featureide.fm.core.base.IFeatureModelElement;
@@ -108,9 +109,11 @@ public class ConstraintViewConstraintColumnLabelProvider extends ColumnLabelProv
 
 			final Boolean isAutomaticCalculation = FeatureModelProperty.getBooleanProperty(controller.getFeatureModelManager().getSnapshot().getProperty(),
 					FeatureModelProperty.TYPE_CALCULATIONS, FeatureModelProperty.PROPERTY_CALCULATIONS_RUN_AUTOMATICALLY);
-			if ((isAutomaticCalculation != null) && isAutomaticCalculation) {
 
-				final ConstraintProperties constraintProperties = controller.getAnalyzer().getAnalysesCollection().getConstraintProperty(constraint);
+			final FeatureModelAnalyzer analyzer = controller.getAnalyzer();
+			if (analyzer != null) {
+
+				final ConstraintProperties constraintProperties = analyzer.getAnalysesCollection().getConstraintProperty(constraint);
 				if (constraintProperties.hasStatus(ConstraintProperties.ConstraintStatus.REDUNDANT)) {
 					return GUIDefaults.FM_INFO;
 				}


### PR DESCRIPTION
Fixed the core issue of a new analyzer being created and run for each
and every constraint. It is now created only once. Additionally, if
"Automatic Calculations" are turned off, the analyzer will not be
created or queried at all.

I have no idea if the changes are idiomatic in terms of the FeatureIDE architecture.