### PR TITLE
Partial fix for issue #795, feature names and constraints with zooming in FM editor

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/figures/ConstraintFigure.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/figures/ConstraintFigure.java
@@ -87,7 +87,7 @@ public class ConstraintFigure extends ModelElementFigure implements GUIDefaults 
 
 		label.setForegroundColor(CONSTRAINT_FOREGROUND);
 		label.setFont(DEFAULT_FONT);
-		label.setLocation(new Point(CONSTRAINT_INSETS.left, CONSTRAINT_INSETS.top));
+		label.setLocation(new Point(0, 0));
 
 		setText(getConstraintText(constraint.getObject()));
 
@@ -211,13 +211,12 @@ public class ConstraintFigure extends ModelElementFigure implements GUIDefaults 
 	 */
 	private void setText(String newText) {
 		label.setText(newText);
+
 		final Dimension labelSize = new Dimension(label.getPreferredSize());
+		labelSize.expand(CONSTRAINT_INSETS.getWidth(), CONSTRAINT_INSETS.getHeight());
+
 		label.setSize(labelSize);
-
-		final int w = CONSTRAINT_INSETS.getWidth();
-		final int h = CONSTRAINT_INSETS.getHeight();
-		setSize(labelSize.expand(w, h));
-
+		setSize(labelSize);
 	}
 
 	public Rectangle getLabelBounds() {

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/figures/FeatureFigure.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/figures/FeatureFigure.java
@@ -97,7 +97,7 @@ public class FeatureFigure extends ModelElementFigure implements GUIDefaults {
 		label.setForegroundColor(FMPropertyManager.getFeatureForgroundColor());
 		label.setFont(DEFAULT_FONT);
 
-		label.setLocation(new Point(FEATURE_INSETS.left, FEATURE_INSETS.top));
+		label.setLocation(new Point(0, 0));
 
 		String displayName = feature.getObject().getName();
 		if (featureModel.getLayout().showShortNames()) {
@@ -110,7 +110,7 @@ public class FeatureFigure extends ModelElementFigure implements GUIDefaults {
 
 		feature.setSize(getSize());
 
-		add(label, label.getBounds());
+		add(label);
 		setOpaque(true);
 
 		if (feature.getLocation() != null) {
@@ -299,20 +299,13 @@ public class FeatureFigure extends ModelElementFigure implements GUIDefaults {
 	public void setName(String newName) {
 		label.setText(newName);
 
-		final Dimension labelSize = label.getPreferredSize();
+		final Dimension labelSize = new Dimension(label.getPreferredSize());
+		labelSize.expand(FEATURE_INSETS.getWidth(), FEATURE_INSETS.getHeight());
 		minSize = labelSize;
 
 		if (!labelSize.equals(label.getSize())) {
 			label.setSize(labelSize);
-
-			final Rectangle bounds = getBounds();
-			bounds.setSize(labelSize.expand(FEATURE_INSETS.getWidth(), FEATURE_INSETS.getHeight()));
-
-			final Dimension oldSize = getSize();
-			if (!oldSize.equals(0, 0)) {
-				bounds.x += (oldSize.width - bounds.width) >> 1;
-			}
-			setBounds(bounds);
+			setSize(labelSize);
 		}
 	}
 


### PR DESCRIPTION
Feature names and constraints are no longer cut off within their bounding box in the feature model editor when zooming.

The problem occurred because the approximated text width provided by the label is slightly different from the actual text width, where the difference depends on the zoom level. The bounding box of features/constraints is slightly larger than the approximated size, which allows text to be fully rendered even if some more space is necessary. The size of the actual text as well as the size of the bounding box were not changed, only the way the text is rendered within the bounds, so it is no longer cut off unnecessarily.

However, if the actual text width is much larger than approximated, and would even exceed the bounding box, it is still cut off. This happens only in specific cases, especially when feature names contain the same letter many times, such as a feature named "iiiiiiiiii".