### PR TITLE
Implemented issue #809, feature models without layout information are adjusted to editor size when opened

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramEditor.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramEditor.java
@@ -1299,7 +1299,7 @@ public class FeatureDiagramEditor extends FeatureModelEditorPage implements GUID
 			menuManager.add(new Separator());
 			menuManager.add(reverseOrderAction);
 			// only show the "Show Collapsed Constraints"-entry when the constraints are visible in the diagram editor
-			if(!graphicalFeatureModel.getConstraintsHidden()) {
+			if (!graphicalFeatureModel.getConstraintsHidden()) {
 				menuManager.add(showCollapsedConstraintsAction);
 			}
 			menuManager.add(new Separator());
@@ -1457,5 +1457,9 @@ public class FeatureDiagramEditor extends FeatureModelEditorPage implements GUID
 
 	public void removeSelectionChangedListener(ISelectionChangedListener listener) {
 		viewer.removeSelectionChangedListener(listener);
+	}
+
+	public void adjustModelToEditorSize() {
+		adjustModelToEditorSizeAction.run();
 	}
 }

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureModelEditor.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureModelEditor.java
@@ -438,6 +438,9 @@ public class FeatureModelEditor extends MultiPageEditorPart implements IEventLis
 
 					@Override
 					public void run() {
+						if (!gfm.hasInitialLayout()) {
+							diagramEditor.adjustModelToEditorSize();
+						}
 						pageChange(getDiagramEditorIndex());
 						diagramEditor.getViewer().internRefresh(false);
 						diagramEditor.analyzeFeatureModel();

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/IGraphicalFeatureModel.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/IGraphicalFeatureModel.java
@@ -43,6 +43,11 @@ public interface IGraphicalFeatureModel extends IGraphicItem, Cloneable {
 
 	IFeatureModelManager getFeatureModelManager();
 
+	/**
+	 * @return True iff the initial feature model, e.g. when opening a file, contains layout information.
+	 */
+	boolean hasInitialLayout();
+
 	FeatureModelLayout getLayout();
 
 	boolean isLegendHidden();

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/elements/GraphicalFeatureModel.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/elements/GraphicalFeatureModel.java
@@ -62,6 +62,7 @@ public class GraphicalFeatureModel implements IGraphicalFeatureModel {
 
 	protected final IFeatureModelManager featureModelManager;
 
+	protected boolean hasInitialLayout = false;
 	protected final FeatureModelLayout layout;
 
 	protected Map<IFeature, IGraphicalFeature> features = new HashMap<>();
@@ -114,6 +115,11 @@ public class GraphicalFeatureModel implements IGraphicalFeatureModel {
 	@Override
 	public GraphicItem getItemType() {
 		return GraphicItem.Model;
+	}
+
+	@Override
+	public boolean hasInitialLayout() {
+		return hasInitialLayout;
 	}
 
 	@Override
@@ -360,6 +366,8 @@ public class GraphicalFeatureModel implements IGraphicalFeatureModel {
 	@Override
 	public void readValues() {
 		final IFeatureModel fm = featureModelManager.getSnapshot();
+
+		hasInitialLayout = fm.getProperty().has(LAYOUT_ALGORITHM, TYPE_GRAPHICS);
 
 		getLayout().setLayout(Integer.parseInt(fm.getProperty().get(LAYOUT_ALGORITHM, TYPE_GRAPHICS, "1")));
 


### PR DESCRIPTION
When opening a feature model without layout information, such as a newly created model or a model in a file format without layout information, it is now automatically adjusted to the editor size.