### PR TITLE
Issue 969

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramEditor.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramEditor.java
@@ -1157,9 +1157,9 @@ public class FeatureDiagramEditor extends FeatureModelEditorPage implements GUID
 				selectedAction.setChecked(true);
 				menuManager.insert(1, new Separator("ManualLayoutSeparator"));
 				menuManager.insertBefore("ManualLayoutSeparator", autoLayoutConstraintAction);
-				final boolean haveAutoLayout = !graphicalFeatureModel.getLayout().hasFeaturesAutoLayout();
-				autoLayoutConstraintAction.setEnabled(haveAutoLayout);
-				autoLayoutConstraintAction.setChecked(haveAutoLayout && graphicalFeatureModel.getLayout().isAutoLayoutConstraints());
+				final boolean enableAutoLayoutConstraints = !graphicalFeatureModel.getLayout().hasFeaturesAutoLayout();
+				autoLayoutConstraintAction.setEnabled(enableAutoLayoutConstraints);
+				autoLayoutConstraintAction.setChecked(enableAutoLayoutConstraints && graphicalFeatureModel.getLayout().isAutoLayoutConstraints());
 			}
 		});
 		return menuManager;

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramEditor.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramEditor.java
@@ -758,7 +758,6 @@ public class FeatureDiagramEditor extends FeatureModelEditorPage implements GUID
 		case CONSTRAINT_MOVE:
 		case CONSTRAINT_MOVE_LOCATION:
 			viewer.internRefresh(true);
-			autoLayoutConstraintAction.setAutoLayoutConstraints(false);
 			setDirty();
 			break;
 		case CONSTRAINT_MODIFY:
@@ -1160,7 +1159,7 @@ public class FeatureDiagramEditor extends FeatureModelEditorPage implements GUID
 				menuManager.insertBefore("ManualLayoutSeparator", autoLayoutConstraintAction);
 				final boolean haveAutoLayout = !graphicalFeatureModel.getLayout().hasFeaturesAutoLayout();
 				autoLayoutConstraintAction.setEnabled(haveAutoLayout);
-				autoLayoutConstraintAction.setChecked(haveAutoLayout && autoLayoutConstraintAction.isAutoLayoutConstraints());
+				autoLayoutConstraintAction.setChecked(haveAutoLayout && graphicalFeatureModel.getLayout().isAutoLayoutConstraints());
 			}
 		});
 		return menuManager;

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramEditor.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramEditor.java
@@ -758,6 +758,7 @@ public class FeatureDiagramEditor extends FeatureModelEditorPage implements GUID
 		case CONSTRAINT_MOVE:
 		case CONSTRAINT_MOVE_LOCATION:
 			viewer.internRefresh(true);
+			autoLayoutConstraintAction.setAutoLayoutConstraints(false);
 			setDirty();
 			break;
 		case CONSTRAINT_MODIFY:
@@ -1157,7 +1158,9 @@ public class FeatureDiagramEditor extends FeatureModelEditorPage implements GUID
 				selectedAction.setChecked(true);
 				menuManager.insert(1, new Separator("ManualLayoutSeparator"));
 				menuManager.insertBefore("ManualLayoutSeparator", autoLayoutConstraintAction);
-				autoLayoutConstraintAction.setEnabled(!graphicalFeatureModel.getLayout().hasFeaturesAutoLayout());
+				final boolean haveAutoLayout = !graphicalFeatureModel.getLayout().hasFeaturesAutoLayout();
+				autoLayoutConstraintAction.setEnabled(haveAutoLayout);
+				autoLayoutConstraintAction.setChecked(haveAutoLayout && autoLayoutConstraintAction.isAutoLayoutConstraints());
 			}
 		});
 		return menuManager;
@@ -1299,7 +1302,7 @@ public class FeatureDiagramEditor extends FeatureModelEditorPage implements GUID
 			menuManager.add(new Separator());
 			menuManager.add(reverseOrderAction);
 			// only show the "Show Collapsed Constraints"-entry when the constraints are visible in the diagram editor
-			if(!graphicalFeatureModel.getConstraintsHidden()) {
+			if (!graphicalFeatureModel.getConstraintsHidden()) {
 				menuManager.add(showCollapsedConstraintsAction);
 			}
 			menuManager.add(new Separator());

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/AutoLayoutConstraintAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/AutoLayoutConstraintAction.java
@@ -43,6 +43,16 @@ public class AutoLayoutConstraintAction extends Action {
 
 	public static final String ID = "de.ovgu.featureide.autolayoutconstraint";
 
+	private boolean autoLayoutConstraints;
+
+	public boolean isAutoLayoutConstraints() {
+		return autoLayoutConstraints;
+	}
+
+	public void setAutoLayoutConstraints(boolean autoLayoutConstraints) {
+		this.autoLayoutConstraints = autoLayoutConstraints;
+	}
+
 	private final IGraphicalFeatureModel featureModel;
 	private final LinkedList<LinkedList<Point>> oldPos = new LinkedList<LinkedList<Point>>();
 
@@ -54,6 +64,10 @@ public class AutoLayoutConstraintAction extends Action {
 
 	@Override
 	public void run() {
+		autoLayoutConstraints = !autoLayoutConstraints;
+		if (!autoLayoutConstraints) {
+			return;
+		}
 		final LinkedList<Point> newList = new LinkedList<Point>();
 		for (int i = 0; i < featureModel.getConstraints().size(); i++) {
 			newList.add(featureModel.getConstraints().get(i).getLocation());

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/AutoLayoutConstraintAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/AutoLayoutConstraintAction.java
@@ -29,6 +29,7 @@ import org.eclipse.gef.ui.parts.GraphicalViewerImpl;
 import org.eclipse.jface.action.Action;
 
 import de.ovgu.featureide.fm.ui.editors.IGraphicalFeatureModel;
+import de.ovgu.featureide.fm.ui.editors.featuremodel.layouts.FeatureModelLayout;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.operations.AutoLayoutConstraintOperation;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.operations.FeatureModelOperationWrapper;
 
@@ -43,16 +44,6 @@ public class AutoLayoutConstraintAction extends Action {
 
 	public static final String ID = "de.ovgu.featureide.autolayoutconstraint";
 
-	private boolean autoLayoutConstraints;
-
-	public boolean isAutoLayoutConstraints() {
-		return autoLayoutConstraints;
-	}
-
-	public void setAutoLayoutConstraints(boolean autoLayoutConstraints) {
-		this.autoLayoutConstraints = autoLayoutConstraints;
-	}
-
 	private final IGraphicalFeatureModel featureModel;
 	private final LinkedList<LinkedList<Point>> oldPos = new LinkedList<LinkedList<Point>>();
 
@@ -60,21 +51,22 @@ public class AutoLayoutConstraintAction extends Action {
 		super(AUTO_LAYOUT_CONSTRAINTS);
 		this.featureModel = featureModel;
 		setId(ID);
+
 	}
 
 	@Override
 	public void run() {
-		autoLayoutConstraints = !autoLayoutConstraints;
-		if (!autoLayoutConstraints) {
-			return;
-		}
 		final LinkedList<Point> newList = new LinkedList<Point>();
 		for (int i = 0; i < featureModel.getConstraints().size(); i++) {
 			newList.add(featureModel.getConstraints().get(i).getLocation());
 		}
-		final int counter = oldPos.size();
-		oldPos.add(newList);
-		FeatureModelOperationWrapper.run(new AutoLayoutConstraintOperation(featureModel, oldPos, counter));
+		final FeatureModelLayout layout = featureModel.getLayout();
+		layout.setAutoLayoutConstraints(!layout.isAutoLayoutConstraints());
+		if (layout.isAutoLayoutConstraints()) {
+			final int counter = oldPos.size();
+			oldPos.add(newList);
+			FeatureModelOperationWrapper.run(new AutoLayoutConstraintOperation(featureModel, oldPos, counter));
+		}
 	}
 
 }

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/layouts/FeatureModelLayout.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/layouts/FeatureModelLayout.java
@@ -39,6 +39,7 @@ public class FeatureModelLayout implements IExtendedFeatureModelLayout {
 	private final Point legendPos;
 	private boolean leftRightInverted;
 	private boolean topDownInverted;
+	private boolean autoLayoutConstraints;
 
 	private int selectedLayoutAlgorithm;
 	private boolean showShortNames;
@@ -50,6 +51,7 @@ public class FeatureModelLayout implements IExtendedFeatureModelLayout {
 		legendPos = new Point(0, 0);
 		selectedLayoutAlgorithm = 4;
 		usesAbegoTreeLayout = false;
+		autoLayoutConstraints = false;
 	}
 
 	protected FeatureModelLayout(FeatureModelLayout featureModelLayout) {
@@ -59,6 +61,15 @@ public class FeatureModelLayout implements IExtendedFeatureModelLayout {
 		legendPos = featureModelLayout.legendPos.getCopy();
 		selectedLayoutAlgorithm = featureModelLayout.selectedLayoutAlgorithm;
 		usesAbegoTreeLayout = featureModelLayout.usesAbegoTreeLayout;
+		autoLayoutConstraints = featureModelLayout.autoLayoutConstraints;
+	}
+
+	public boolean isAutoLayoutConstraints() {
+		return autoLayoutConstraints;
+	}
+
+	public void setAutoLayoutConstraints(boolean autoLayoutConstraints) {
+		this.autoLayoutConstraints = autoLayoutConstraints;
 	}
 
 	@Override

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/layouts/ManualLayout.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/layouts/ManualLayout.java
@@ -20,9 +20,12 @@
  */
 package de.ovgu.featureide.fm.ui.editors.featuremodel.layouts;
 
+import de.ovgu.featureide.fm.core.base.FeatureUtils;
+import de.ovgu.featureide.fm.ui.editors.FeatureUIHelper;
 import de.ovgu.featureide.fm.ui.editors.IGraphicalConstraint;
 import de.ovgu.featureide.fm.ui.editors.IGraphicalFeature;
 import de.ovgu.featureide.fm.ui.editors.IGraphicalFeatureModel;
+import de.ovgu.featureide.fm.ui.properties.FMPropertyManager;
 
 /**
  * Layouts the features at the feature diagram using their saved Positions.
@@ -42,8 +45,23 @@ public class ManualLayout extends FeatureDiagramLayoutManager {
 		for (final IGraphicalFeature feature : featureModel.getVisibleFeatures()) {
 			setLocation(feature, feature.getLocation());
 		}
-		for (final IGraphicalConstraint constraint : featureModel.getVisibleConstraints()) {
-			constraint.setLocation(constraint.getLocation());
+		if (featureModel.getLayout().isAutoLayoutConstraints()) {
+			final IGraphicalFeature root =
+				FeatureUIHelper.getGraphicalFeature(FeatureUtils.getRoot(featureModel.getFeatureModelManager().getSnapshot()), featureModel);
+			// Calculate yoffset as the position of the lowest visible feature + its height.
+			int yoffset = FMPropertyManager.getLayoutMarginY();
+
+			for (final IGraphicalFeature feat : featureModel.getVisibleFeatures()) {
+				if (yoffset < feat.getLocation().y) {
+					yoffset += FMPropertyManager.getFeatureSpaceY();
+				}
+			}
+
+			layoutConstraints(yoffset, featureModel.getVisibleConstraints(), getBounds(root));
+		} else {
+			for (final IGraphicalConstraint constraint : featureModel.getVisibleConstraints()) {
+				constraint.setLocation(constraint.getLocation());
+			}
 		}
 	}
 

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/layouts/ManualLayout.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/layouts/ManualLayout.java
@@ -25,7 +25,6 @@ import de.ovgu.featureide.fm.ui.editors.FeatureUIHelper;
 import de.ovgu.featureide.fm.ui.editors.IGraphicalConstraint;
 import de.ovgu.featureide.fm.ui.editors.IGraphicalFeature;
 import de.ovgu.featureide.fm.ui.editors.IGraphicalFeatureModel;
-import de.ovgu.featureide.fm.ui.properties.FMPropertyManager;
 
 /**
  * Layouts the features at the feature diagram using their saved Positions.
@@ -48,12 +47,12 @@ public class ManualLayout extends FeatureDiagramLayoutManager {
 		if (featureModel.getLayout().isAutoLayoutConstraints()) {
 			final IGraphicalFeature root =
 				FeatureUIHelper.getGraphicalFeature(FeatureUtils.getRoot(featureModel.getFeatureModelManager().getSnapshot()), featureModel);
-			// Calculate yoffset as the position of the lowest visible feature + its height.
-			int yoffset = FMPropertyManager.getLayoutMarginY();
 
+			// Calculate yoffset as the position of the lowest visible feature + its height.
+			int yoffset = 0;
 			for (final IGraphicalFeature feat : featureModel.getVisibleFeatures()) {
 				if (yoffset < feat.getLocation().y) {
-					yoffset += FMPropertyManager.getFeatureSpaceY();
+					yoffset = feat.getLocation().y;
 				}
 			}
 


### PR DESCRIPTION
"FeatureModelLayout" now also hast the boolean "isAutoLayoutConstraint". The option Auto Layout Constraint int the context menu is now a toggle and if activated, it is not possible to move the constraints. Additionally, the constraints adapt to the featuremodel layout even in manual layout with the toggle activated. 