### PR TITLE
CollapseAction now implements ActionAllowedInExternalSubmodel, so

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/CollapseAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/CollapseAction.java
@@ -55,7 +55,7 @@ import de.ovgu.featureide.fm.ui.views.outline.standard.FmOutlineGroupStateStorag
  * @author Chico Sundermann
  * @author Paul Westphal
  */
-public class CollapseAction extends MultipleSelectionAction {
+public class CollapseAction extends MultipleSelectionAction implements ActionAllowedInExternalSubmodel {
 
 	public static final String ID = "de.ovgu.featureide.collapse";
 	private final IGraphicalFeatureModel graphicalFeatureModel;


### PR DESCRIPTION
Features from external submodels can be collapsed. Fixes issue #1141

Added Interface `ActionAllowedInExternalSubmodel` to ` CollapseAction`