### PR TITLE
Fixes #1126

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/utils/SearchField.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/utils/SearchField.java
@@ -61,6 +61,7 @@ public class SearchField<T> {
 	}
 
 	private final class SearchModifyListener implements ModifyListener {
+
 		@Override
 		public void modifyText(ModifyEvent e) {
 			curIndex = 0;
@@ -154,15 +155,17 @@ public class SearchField<T> {
 	}
 
 	private void expand(T next) {
-		if (((IGraphicalFeature) next).getSourceConnection().getTarget() != null) {
-			final IGraphicalFeature parent = ((IGraphicalFeature) next).getSourceConnection().getTarget();
-			if (parent.getSourceConnection().getTarget() != null) {
-				expand((T) parent);
-			}
-			if (parent.isCollapsed()) {
-				parent.setCollapsed(false);
-				if (featureDiagramEditor != null) {
-					refresh();
+		if (next instanceof IGraphicalFeature) {
+			if (((IGraphicalFeature) next).getSourceConnection().getTarget() != null) {
+				final IGraphicalFeature parent = ((IGraphicalFeature) next).getSourceConnection().getTarget();
+				if (parent.getSourceConnection().getTarget() != null) {
+					expand((T) parent);
+				}
+				if (parent.isCollapsed()) {
+					parent.setCollapsed(false);
+					if (featureDiagramEditor != null) {
+						refresh();
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Added type checking in expand method. This avoids a class cast exception when calling the method when in the configuration editor where we have tree items. The expand method is not necessary for the search box in the configuration editor anyway so this fix is enough. 
