### PR TITLE
Issue #1076 Task 2: Improved validation of UVL format

### DIFF
--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
@@ -148,7 +148,7 @@ public class UVLFeatureModelFormat extends AFeatureModelFormat {
 		if (resolved.getName().contains(".")) {
 			final String alias = resolved.getName().split("\\.")[0];
 			if (!fm.getExternalModels().containsKey(alias)) {
-				pl.add(new Problem("Cannot resolve alias " + alias, 0, Severity.ERROR));
+				pl.add(new Problem("Cannot resolve alias " + alias + " of feature " + resolved.getName(), 0, Severity.ERROR));
 			}
 		}
 		final MultiFeature feature = MultiFeatureModelFactory.getInstance().createFeature(fm, resolved.getName());


### PR DESCRIPTION
Closes #1076. The source tab of the feature model editor, when used with UVL models, now validates imported features. In particular, the following cases are now considered errors:
- References to imported features with an unknown alias or qualified name
- References to imported features where the feature is not declared as a root feature in the imported model
- Attributes of imported features declared in the importing model
- Feature groups of imported features declared in the importing model

These errors correctly prevent saving of the model or switching to the feature diagram tab.

Additionally, references in constraints to non-existent features are now also considered as errors (instead of warnings), and thus prevent saving or switching to the feature diagram tab.