### PR TITLE
FeatureIDE Outline now appears for UVL Models.

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/outline/custom/OutlineProvider.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/outline/custom/OutlineProvider.java
@@ -35,9 +35,9 @@ import de.ovgu.featureide.fm.core.io.manager.FeatureModelManager;
 import de.ovgu.featureide.fm.ui.views.outline.custom.filters.IOutlineFilter;
 
 /**
- * Provides all data needed for the FeatureIDE Outline A provider consists of: <ul> <li>OutlineTreeContentProvider</li> <li>OutlineLabelProvider</li>
+ * Provides all data needed for the FeatureIDE Outline. A provider consists of: <ul> <li>OutlineTreeContentProvider</li> <li>OutlineLabelProvider</li>
  * <li>ContextMenuActions</li> <li>ToolbarActions</li> <li>Filters</li> </ul> A check is performed to determine if the provider is applicable through the
- * isSupported method
+ * {@link OutlineProvider#isSupported} method.
  *
  * @author Christopher Sontag
  */

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/outline/custom/providers/FMOutlineProvider.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/outline/custom/providers/FMOutlineProvider.java
@@ -54,6 +54,16 @@ import de.ovgu.featureide.fm.ui.views.outline.custom.OutlineTreeContentProvider;
 import de.ovgu.featureide.fm.ui.views.outline.custom.action.SyncCollapsedStateAction;
 import de.ovgu.featureide.fm.ui.views.outline.custom.filters.IOutlineFilter;
 
+/**
+ * FMOutlineProvider provides specifically the data for the currently shown feature model in a {@link FeatureModelEditor}.
+ *
+ * @author Christopher Sontag
+ * @author Thomas Thuem
+ * @author Sebastian Krieter
+ * @author Joshua Sprey
+ * @author Chico Sundermann
+ * @author Benedikt Jutz
+ */
 public class FMOutlineProvider extends OutlineProvider implements IEventListener {
 
 	private SyncCollapsedStateAction syncCollapsedStateAction;
@@ -68,12 +78,20 @@ public class FMOutlineProvider extends OutlineProvider implements IEventListener
 		super(treeProvider, labelProvider);
 	}
 
+	/**
+	 * FMOutlineProvider supports feature models in the FeatureIDE format (File ending .xml), and UVL models (File ending .uvl).
+	 *
+	 * @see {@link OutlineProvider#isSupported(IEditorPart, IFile)}
+	 */
 	@Override
 	public boolean isSupported(IEditorPart part, IFile file) {
-		if (file != null) {
-			return "xml".equalsIgnoreCase(file.getFileExtension()) && (FMFormatManager.getInstance().hasFormat(EclipseFileSystem.getPath(file)));
+		if (file == null) {
+			return false;
 		}
-		return false;
+
+		final String extension = file.getFileExtension();
+		return ("xml".equalsIgnoreCase(extension) || "uvl".equalsIgnoreCase(extension))
+			&& (FMFormatManager.getInstance().hasFormat(EclipseFileSystem.getPath(file)));
 	}
 
 	@Override


### PR DESCRIPTION
FMOutlineProvider now also accepts UVL files with the .uvl file ending (FMOutlineProvider.isSupported).
closes #1157 