### PR TITLE
Fixes Issue #1127

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramViewer.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramViewer.java
@@ -296,6 +296,12 @@ public class FeatureDiagramViewer extends ScrollingGraphicalViewer implements IS
 				}
 			}
 		}
+
+		if (!graphicalFeatureModel.isLegendHidden()) {
+			if (graphicalFeatureModel.getLayout().hasLegendAutoLayout()) {
+				layoutManager.layoutLegend(graphicalFeatureModel);
+			}
+		}
 	}
 
 	public void layoutLegendOnIntersect() {

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramViewer.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramViewer.java
@@ -297,11 +297,6 @@ public class FeatureDiagramViewer extends ScrollingGraphicalViewer implements IS
 			}
 		}
 
-		if (!graphicalFeatureModel.isLegendHidden()) {
-			if (graphicalFeatureModel.getLayout().hasLegendAutoLayout()) {
-				layoutManager.layoutLegend(graphicalFeatureModel);
-			}
-		}
 	}
 
 	public void layoutLegendOnIntersect() {

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/FeatureModelBounds.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/FeatureModelBounds.java
@@ -80,6 +80,9 @@ public class FeatureModelBounds {
 							if ((position.bottom()) > max.y) {
 								max.y = position.bottom();
 							}
+							if (element.getGraphicalModel().getLayout().hasVerticalLayout()) {
+								max.x = max.x + position.width;
+							}
 						}
 					}
 				}

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/FeatureModelBounds.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/FeatureModelBounds.java
@@ -67,17 +67,19 @@ public class FeatureModelBounds {
 					if (((IGraphicalFeature) element).getCollapsedDecoration() != null) {
 						final CollapsedDecoration collapsedDecoration = ((IGraphicalFeature) element).getCollapsedDecoration();
 						position = getBounds(collapsedDecoration);
-						if (position.x < min.x) {
-							min.x = position.x;
-						}
-						if (position.y < min.y) {
-							min.y = position.y;
-						}
-						if ((position.right()) > max.x) {
-							max.x = position.right();
-						}
-						if ((position.bottom()) > max.y) {
-							max.y = position.bottom();
+						if (!((position.x == 0) && (position.y == 0))) {
+							if (position.x < min.x) {
+								min.x = position.x;
+							}
+							if (position.y < min.y) {
+								min.y = position.y;
+							}
+							if ((position.right()) > max.x) {
+								max.x = position.right();
+							}
+							if ((position.bottom()) > max.y) {
+								max.y = position.bottom();
+							}
 						}
 					}
 				}

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/FeatureModelBounds.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/FeatureModelBounds.java
@@ -80,9 +80,6 @@ public class FeatureModelBounds {
 							if ((position.bottom()) > max.y) {
 								max.y = position.bottom();
 							}
-							if (element.getGraphicalModel().getLayout().hasVerticalLayout()) {
-								max.x = max.x + position.width;
-							}
 						}
 					}
 				}

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/FeatureModelBounds.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/FeatureModelBounds.java
@@ -41,6 +41,7 @@ public class FeatureModelBounds {
 	public Rectangle getFeatureModelBounds(List<? extends IGraphicalElement> elements) {
 		final Point min = new Point(Integer.MAX_VALUE, Integer.MAX_VALUE);
 		final Point max = new Point(Integer.MIN_VALUE, Integer.MIN_VALUE);
+		boolean mostRightFeature = false;
 
 		/*
 		 * update lowest, highest, most left, most right coordinates for elements
@@ -56,6 +57,7 @@ public class FeatureModelBounds {
 				min.y = position.y;
 			}
 			if ((position.right()) > max.x) {
+				mostRightFeature = true;
 				max.x = position.right();
 			}
 			if ((position.bottom()) > max.y) {
@@ -80,10 +82,15 @@ public class FeatureModelBounds {
 							if ((position.bottom()) > max.y) {
 								max.y = position.bottom();
 							}
+						} else if (mostRightFeature) {
+							if (element.getGraphicalModel().getLayout().hasVerticalLayout()) {
+								max.x = max.x + position.width;
+							}
 						}
 					}
 				}
 			}
+			mostRightFeature = false;
 		}
 		return new Rectangle(min, max);
 	}

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/layouts/FeatureDiagramLayoutManager.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/layouts/FeatureDiagramLayoutManager.java
@@ -88,6 +88,12 @@ abstract public class FeatureDiagramLayoutManager {
 			firstManualLayout = false;
 		}
 
+		if (!featureModel.isLegendHidden()) {
+			if (featureModel.getLayout().hasLegendAutoLayout()) {
+				layoutLegend(featureModel);
+			}
+		}
+
 		newLocations.clear();
 	}
 

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/layouts/FeatureDiagramLayoutManager.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/layouts/FeatureDiagramLayoutManager.java
@@ -88,11 +88,6 @@ abstract public class FeatureDiagramLayoutManager {
 			firstManualLayout = false;
 		}
 
-		if (!featureModel.isLegendHidden()) {
-			if (featureModel.getLayout().hasLegendAutoLayout()) {
-				layoutLegend(featureModel);
-			}
-		}
 		newLocations.clear();
 	}
 


### PR DESCRIPTION
Fixes Issue #1127 

* Check if a decoration box already has an assigned position before taking it into account when calculating feature model bounds
* Move the legend about a size of a decoration box to the right in the edge case that we have a vertical layout and a decoration box at the most right feature that has no position assigned yet. 