### PR TITLE
Fixes issue #1142

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/MultipleSelectionAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/MultipleSelectionAction.java
@@ -186,8 +186,8 @@ public abstract class MultipleSelectionAction extends AFeatureModelAction implem
 	public void propertyChange(FeatureIDEEvent event) {
 		final EventType prop = event.getEventType();
 		if (EventType.GROUP_TYPE_CHANGED.equals(prop) || EventType.MANDATORY_CHANGED.equals(prop) || EventType.PARENT_CHANGED.equals(prop)
-			|| EventType.FEATURE_HIDDEN_CHANGED.equals(prop) || EventType.FEATURE_COLOR_CHANGED.equals(prop)
-			|| EventType.FEATURE_COLLAPSED_CHANGED.equals(prop)) {
+			|| EventType.FEATURE_HIDDEN_CHANGED.equals(prop) || EventType.FEATURE_COLOR_CHANGED.equals(prop) || EventType.FEATURE_COLLAPSED_CHANGED.equals(prop)
+			|| EventType.ATTRIBUTE_CHANGED.equals(prop)) {
 			updateProperties();
 		}
 	}


### PR DESCRIPTION
Collapsing a feature is an "attribute-changed" event. Therefore, action properties have to be updated for those events as well.