### PR TITLE
Fixes Issue #1164

### DIFF
--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/base/impl/MultiFeatureModel.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/base/impl/MultiFeatureModel.java
@@ -159,6 +159,18 @@ public class MultiFeatureModel extends FeatureModel {
 		attributeConstraints.add(constraint);
 	}
 
+	@Override
+	public void addConstraint(IConstraint constraint) {
+		addOwnConstraint(constraint);
+		elements.put(constraint.getInternalId(), constraint);
+	}
+
+	@Override
+	public void addConstraint(IConstraint constraint, int index) {
+		addOwnConstraint(constraint);
+		elements.put(constraint.getInternalId(), constraint);
+	}
+
 	public void addOwnConstraint(final IConstraint constraint) {
 		ownConstraints.add(constraint);
 		constraints.add(constraint);


### PR DESCRIPTION
Overwrite the addConstraint method for MultiFeaturemodels. Now the constraints are also added to ownConstraints (a list containing the constraints of a multi feature model with submodels).