### PR TITLE
Fixes #1110

### DIFF
--- a/plugins/de.ovgu.featureide.core.runtime/src/de/ovgu/featureide/core/runtime/RuntimeParameters.java
+++ b/plugins/de.ovgu.featureide.core.runtime/src/de/ovgu/featureide/core/runtime/RuntimeParameters.java
@@ -484,7 +484,14 @@ public class RuntimeParameters extends ComposerExtensionClass {
 			for (final CallLocation[] callLoc : callLocs) {
 				for (final CallLocation element : callLoc) {
 					// feature name = attribute of getProperty-call
-					featureName = element.getCallText().split("\"")[1];
+					
+					String[] callTextElements = element.getCallText().split("\"");
+					
+					if(callTextElements.length < 2) {
+						continue;
+					}
+					featureName = callTextElements[1];
+					
 					className = element.getMember().getParent().getElementName();
 					classFile = (IFile) element.getMember().getCompilationUnit().getCorrespondingResource();
 					compilationUnit = element.getMember().getCompilationUnit();


### PR DESCRIPTION
Fixes #1110 

Calls to `getProperty` which are not literals are now ignored. For the
future it would be desirable to taint improper code in the editor, or
yield a warning.