### PR TITLE
Fixes #1195: Select All, Delete and Undo/Redo when renaming a feature

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramViewer.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramViewer.java
@@ -40,6 +40,7 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.part.CellEditorActionHandler;
 
 import de.ovgu.featureide.fm.core.base.IFeature;
 import de.ovgu.featureide.fm.core.base.IFeatureStructure;
@@ -126,6 +127,8 @@ public class FeatureDiagramViewer extends ScrollingGraphicalViewer implements IS
 	private FeatureDiagramLayoutManager layoutManager;
 
 	private boolean openConstraintViewDecisionDialogAlreadySpawned = false;
+
+	private CellEditorActionHandler cellEditorActionHandler;
 
 	/**
 	 * Constructor. Handles editable and read-only feature models.
@@ -426,6 +429,14 @@ public class FeatureDiagramViewer extends ScrollingGraphicalViewer implements IS
 
 	public void setZoomManager(ZoomManager zoomManager) {
 		this.zoomManager = zoomManager;
+	}
+
+	public CellEditorActionHandler getCellEditorActionHandler() {
+		return cellEditorActionHandler;
+	}
+
+	public void setCellEditorActionHandler(CellEditorActionHandler cellEditorActionHandler) {
+		this.cellEditorActionHandler = cellEditorActionHandler;
 	}
 
 	public void createMouseHandlers() {

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/FeatureModelEditorContributor.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/FeatureModelEditorContributor.java
@@ -38,6 +38,7 @@ import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.ide.IDEActionFactory;
+import org.eclipse.ui.part.CellEditorActionHandler;
 import org.eclipse.ui.part.EditorActionBarContributor;
 import org.eclipse.ui.texteditor.ITextEditor;
 
@@ -58,9 +59,9 @@ import de.ovgu.featureide.fm.ui.editors.featuremodel.actions.OrAction;
  */
 public class FeatureModelEditorContributor extends EditorActionBarContributor {
 
-	private static final String[] DIAGRAM_ACTION_IDS = { CreateFeatureBelowAction.ID, CreateFeatureAboveAction.ID, CalculateDependencyAction.ID, DeleteAction.ID,
-		MandatoryAction.ID, AndAction.ID, OrAction.ID, AlternativeAction.ID, ActionFactory.UNDO.getId(), ActionFactory.REDO.getId(),
-		ActionFactory.SELECT_ALL.getId(), ActionFactory.PRINT.getId(), GEFActionConstants.ZOOM_IN, GEFActionConstants.ZOOM_OUT, };
+	private static final String[] DIAGRAM_ACTION_IDS =
+		{ CreateFeatureBelowAction.ID, CreateFeatureAboveAction.ID, CalculateDependencyAction.ID, MandatoryAction.ID, AndAction.ID, OrAction.ID,
+			AlternativeAction.ID, ActionFactory.PRINT.getId(), GEFActionConstants.ZOOM_IN, GEFActionConstants.ZOOM_OUT, };
 
 	private static final String[] TEXTEDITOR_ACTION_IDS =
 		{ ActionFactory.DELETE.getId(), ActionFactory.CUT.getId(), ActionFactory.COPY.getId(), ActionFactory.PASTE.getId(), ActionFactory.SELECT_ALL.getId(),
@@ -77,6 +78,14 @@ public class FeatureModelEditorContributor extends EditorActionBarContributor {
 		for (int i = 0; i < DIAGRAM_ACTION_IDS.length; i++) {
 			actionBars.setGlobalActionHandler(DIAGRAM_ACTION_IDS[i], editor.getDiagramAction(DIAGRAM_ACTION_IDS[i]));
 		}
+
+		// Register actions that need to be redirected if a cell editor (used for renaming a feature) is active
+		final CellEditorActionHandler ceah = new CellEditorActionHandler(actionBars);
+		ceah.setUndoAction(editor.getDiagramAction(ActionFactory.UNDO.getId()));
+		ceah.setRedoAction(editor.getDiagramAction(ActionFactory.REDO.getId()));
+		ceah.setDeleteAction(editor.getDiagramAction(DeleteAction.ID));
+		ceah.setSelectAllAction(editor.getDiagramAction(ActionFactory.SELECT_ALL.getId()));
+		editor.diagramEditor.getViewer().setCellEditorActionHandler(ceah);
 	}
 
 	private void hookGlobalTextActions(FeatureModelEditor editor, IActionBars actionBars) {

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/commands/renaming/FeatureLabelEditManager.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/commands/renaming/FeatureLabelEditManager.java
@@ -33,6 +33,7 @@ import org.eclipse.jface.viewers.ICellEditorListener;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.ToolTip;
+import org.eclipse.ui.part.CellEditorActionHandler;
 
 import de.ovgu.featureide.fm.core.FMComposerManager;
 import de.ovgu.featureide.fm.core.IFMComposerExtension;
@@ -40,6 +41,7 @@ import de.ovgu.featureide.fm.core.base.FeatureUtils;
 import de.ovgu.featureide.fm.core.base.IFeatureModel;
 import de.ovgu.featureide.fm.core.functional.Functional;
 import de.ovgu.featureide.fm.core.io.manager.IManager;
+import de.ovgu.featureide.fm.ui.editors.FeatureDiagramViewer;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.GUIDefaults;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.editparts.FeatureEditPart;
 
@@ -54,11 +56,13 @@ import de.ovgu.featureide.fm.ui.editors.featuremodel.editparts.FeatureEditPart;
 public class FeatureLabelEditManager extends DirectEditManager implements GUIDefaults {
 
 	private final IManager<IFeatureModel> featureModelManager;
+	private final FeatureEditPart editPart;
 
-	public FeatureLabelEditManager(FeatureEditPart editpart, Class<?> editorType, FeatureCellEditorLocator locator,
+	public FeatureLabelEditManager(FeatureEditPart editPart, Class<?> editorType, FeatureCellEditorLocator locator,
 			IManager<IFeatureModel> featureModelManager) {
-		super(editpart, editorType, locator);
+		super(editPart, editorType, locator);
 		this.featureModelManager = featureModelManager;
+		this.editPart = editPart;
 	}
 
 	@Override
@@ -66,9 +70,14 @@ public class FeatureLabelEditManager extends DirectEditManager implements GUIDef
 		final CellEditor cellEditor = getCellEditor();
 		final Control control = cellEditor.getControl();
 		final String oldValue = ((FeatureEditPart) getEditPart()).getModel().getObject().getName();
+		final CellEditorActionHandler ceah = ((FeatureDiagramViewer) editPart.getViewer()).getCellEditorActionHandler();
 
 		control.setFont(DEFAULT_FONT);
 		cellEditor.setValue(oldValue);
+
+		if (ceah != null) {
+			ceah.addCellEditor(cellEditor);
+		}
 
 		cellEditor.addListener(new ICellEditorListener() {
 


### PR DESCRIPTION
Fixes #1195. Select All, Delete and Undo/Redo now work correctly when renaming a feature. These actions are redirected to the text cell editor and no longer affect the feature model itself. In particular:
- Select All selects the entire feature name
- Delete deletes the character at the current caret position
- Undo/Redo has no effect