### PR TITLE
Fixes #1181 (#1205)

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/figures/LegendFigure.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/figures/LegendFigure.java
@@ -306,11 +306,11 @@ public class LegendFigure extends Figure implements GUIDefaults {
 		}
 		if (or) {
 			height = height + ROW_HEIGHT;
-			setWidth(language.getOptional());
+			setWidth(language.getOrGroup());
 		}
 		if (alternative) {
 			height = height + ROW_HEIGHT;
-			setWidth(language.getAlternative());
+			setWidth(language.getAlternativeGroup());
 		}
 		if (_abstract && !concrete) {
 			height = height + ROW_HEIGHT;


### PR DESCRIPTION
When declaring the legend size, we set the width with regards to the
String "Alternative Group" not "Alternative".
Additionally, now the width is set by the word "Or Group" not "Optional"
for "Or Group". (Was a not recognized mistake since this size is
probably never declared)