### PR TITLE
Issue 1005

### DIFF
--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/localization/StringTable.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/localization/StringTable.java
@@ -816,6 +816,7 @@ public class StringTable {
 	public static final String DATA_WAS_SUCCESSFULLY_EXPORTED_ = "Data was successfully exported.";
 	public static final String SUCCESS = "Success";
 	public static final String PLEASE_OPEN_A_FEATURE_DIAGRAM_EDITOR = "Please open a feature diagram editor.";
+	public static final String PLEASE_OPEN_A_FEATUREIDE_PROJECT = "Please open a FeatureIDE project.";
 	public static final String MODEL_NOT_SUPPORTED_PLEASE_CONVERT_TO_EXTENDED_MODEL =
 		"The open feature model does not support attributes. To use attributes convert your feature model to an extended feature model.";
 	public static final String CONFIG_NOT_SUPPORTED_PLEASE_CREATE_EXTENDED_CONFIG =

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramViewer.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramViewer.java
@@ -40,6 +40,7 @@ import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.part.CellEditorActionHandler;
 
 import de.ovgu.featureide.fm.core.base.IFeature;
 import de.ovgu.featureide.fm.core.base.IFeatureStructure;
@@ -126,6 +127,8 @@ public class FeatureDiagramViewer extends ScrollingGraphicalViewer implements IS
 	private FeatureDiagramLayoutManager layoutManager;
 
 	private boolean openConstraintViewDecisionDialogAlreadySpawned = false;
+
+	private CellEditorActionHandler cellEditorActionHandler;
 
 	/**
 	 * Constructor. Handles editable and read-only feature models.
@@ -426,6 +429,14 @@ public class FeatureDiagramViewer extends ScrollingGraphicalViewer implements IS
 
 	public void setZoomManager(ZoomManager zoomManager) {
 		this.zoomManager = zoomManager;
+	}
+
+	public CellEditorActionHandler getCellEditorActionHandler() {
+		return cellEditorActionHandler;
+	}
+
+	public void setCellEditorActionHandler(CellEditorActionHandler cellEditorActionHandler) {
+		this.cellEditorActionHandler = cellEditorActionHandler;
 	}
 
 	public void createMouseHandlers() {

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/FeatureModelEditorContributor.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/FeatureModelEditorContributor.java
@@ -38,6 +38,7 @@ import org.eclipse.ui.IActionBars;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.ide.IDEActionFactory;
+import org.eclipse.ui.part.CellEditorActionHandler;
 import org.eclipse.ui.part.EditorActionBarContributor;
 import org.eclipse.ui.texteditor.ITextEditor;
 
@@ -58,9 +59,9 @@ import de.ovgu.featureide.fm.ui.editors.featuremodel.actions.OrAction;
  */
 public class FeatureModelEditorContributor extends EditorActionBarContributor {
 
-	private static final String[] DIAGRAM_ACTION_IDS = { CreateFeatureBelowAction.ID, CreateFeatureAboveAction.ID, CalculateDependencyAction.ID, DeleteAction.ID,
-		MandatoryAction.ID, AndAction.ID, OrAction.ID, AlternativeAction.ID, ActionFactory.UNDO.getId(), ActionFactory.REDO.getId(),
-		ActionFactory.SELECT_ALL.getId(), ActionFactory.PRINT.getId(), GEFActionConstants.ZOOM_IN, GEFActionConstants.ZOOM_OUT, };
+	private static final String[] DIAGRAM_ACTION_IDS =
+		{ CreateFeatureBelowAction.ID, CreateFeatureAboveAction.ID, CalculateDependencyAction.ID, MandatoryAction.ID, AndAction.ID, OrAction.ID,
+			AlternativeAction.ID, ActionFactory.PRINT.getId(), GEFActionConstants.ZOOM_IN, GEFActionConstants.ZOOM_OUT, };
 
 	private static final String[] TEXTEDITOR_ACTION_IDS =
 		{ ActionFactory.DELETE.getId(), ActionFactory.CUT.getId(), ActionFactory.COPY.getId(), ActionFactory.PASTE.getId(), ActionFactory.SELECT_ALL.getId(),
@@ -77,6 +78,14 @@ public class FeatureModelEditorContributor extends EditorActionBarContributor {
 		for (int i = 0; i < DIAGRAM_ACTION_IDS.length; i++) {
 			actionBars.setGlobalActionHandler(DIAGRAM_ACTION_IDS[i], editor.getDiagramAction(DIAGRAM_ACTION_IDS[i]));
 		}
+
+		// Register actions that need to be redirected if a cell editor (used for renaming a feature) is active
+		final CellEditorActionHandler ceah = new CellEditorActionHandler(actionBars);
+		ceah.setUndoAction(editor.getDiagramAction(ActionFactory.UNDO.getId()));
+		ceah.setRedoAction(editor.getDiagramAction(ActionFactory.REDO.getId()));
+		ceah.setDeleteAction(editor.getDiagramAction(DeleteAction.ID));
+		ceah.setSelectAllAction(editor.getDiagramAction(ActionFactory.SELECT_ALL.getId()));
+		editor.diagramEditor.getViewer().setCellEditorActionHandler(ceah);
 	}
 
 	private void hookGlobalTextActions(FeatureModelEditor editor, IActionBars actionBars) {

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/commands/renaming/FeatureLabelEditManager.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/commands/renaming/FeatureLabelEditManager.java
@@ -33,6 +33,7 @@ import org.eclipse.jface.viewers.ICellEditorListener;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.ToolTip;
+import org.eclipse.ui.part.CellEditorActionHandler;
 
 import de.ovgu.featureide.fm.core.FMComposerManager;
 import de.ovgu.featureide.fm.core.IFMComposerExtension;
@@ -40,6 +41,7 @@ import de.ovgu.featureide.fm.core.base.FeatureUtils;
 import de.ovgu.featureide.fm.core.base.IFeatureModel;
 import de.ovgu.featureide.fm.core.functional.Functional;
 import de.ovgu.featureide.fm.core.io.manager.IManager;
+import de.ovgu.featureide.fm.ui.editors.FeatureDiagramViewer;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.GUIDefaults;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.editparts.FeatureEditPart;
 
@@ -54,11 +56,13 @@ import de.ovgu.featureide.fm.ui.editors.featuremodel.editparts.FeatureEditPart;
 public class FeatureLabelEditManager extends DirectEditManager implements GUIDefaults {
 
 	private final IManager<IFeatureModel> featureModelManager;
+	private final FeatureEditPart editPart;
 
-	public FeatureLabelEditManager(FeatureEditPart editpart, Class<?> editorType, FeatureCellEditorLocator locator,
+	public FeatureLabelEditManager(FeatureEditPart editPart, Class<?> editorType, FeatureCellEditorLocator locator,
 			IManager<IFeatureModel> featureModelManager) {
-		super(editpart, editorType, locator);
+		super(editPart, editorType, locator);
 		this.featureModelManager = featureModelManager;
+		this.editPart = editPart;
 	}
 
 	@Override
@@ -66,9 +70,14 @@ public class FeatureLabelEditManager extends DirectEditManager implements GUIDef
 		final CellEditor cellEditor = getCellEditor();
 		final Control control = cellEditor.getControl();
 		final String oldValue = ((FeatureEditPart) getEditPart()).getModel().getObject().getName();
+		final CellEditorActionHandler ceah = ((FeatureDiagramViewer) editPart.getViewer()).getCellEditorActionHandler();
 
 		control.setFont(DEFAULT_FONT);
 		cellEditor.setValue(oldValue);
+
+		if (ceah != null) {
+			ceah.addCellEditor(cellEditor);
+		}
 
 		cellEditor.addListener(new ICellEditorListener() {
 

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/FeatureEditPart.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/FeatureEditPart.java
@@ -38,6 +38,7 @@ import de.ovgu.featureide.fm.core.base.IConstraint;
 import de.ovgu.featureide.fm.core.base.IFeature;
 import de.ovgu.featureide.fm.core.base.event.FeatureIDEEvent;
 import de.ovgu.featureide.fm.core.base.event.FeatureIDEEvent.EventType;
+import de.ovgu.featureide.fm.core.base.impl.MultiFeature;
 import de.ovgu.featureide.fm.core.editing.FeatureModelToNodeTraceModel.Origin;
 import de.ovgu.featureide.fm.core.explanations.fm.FeatureModelReason;
 import de.ovgu.featureide.fm.ui.FMUIPlugin;
@@ -121,7 +122,9 @@ public class FeatureEditPart extends ModelElementEditPart implements NodeEditPar
 		}
 
 		if (request.getType() == RequestConstants.REQ_DIRECT_EDIT) {
-			showRenameManager();
+			if (!((feature != null) && (feature instanceof MultiFeature) && ((MultiFeature) feature).isFromExtern())) {
+				showRenameManager();
+			}
 		} else if (request.getType() == RequestConstants.REQ_OPEN) {
 			FeatureModelOperationWrapper.run(new CollapseFeatureOperation(feature.getName(), featureModel, COLLAPSE_OPERATION));
 		} else if (request.getType() == RequestConstants.REQ_SELECTION) {

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/figures/LegendFigure.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/figures/LegendFigure.java
@@ -306,11 +306,11 @@ public class LegendFigure extends Figure implements GUIDefaults {
 		}
 		if (or) {
 			height = height + ROW_HEIGHT;
-			setWidth(language.getOptional());
+			setWidth(language.getOrGroup());
 		}
 		if (alternative) {
 			height = height + ROW_HEIGHT;
-			setWidth(language.getAlternative());
+			setWidth(language.getAlternativeGroup());
 		}
 		if (_abstract && !concrete) {
 			height = height + ROW_HEIGHT;

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/operations/CollapseAllOperation.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/operations/CollapseAllOperation.java
@@ -21,6 +21,7 @@
 package de.ovgu.featureide.fm.ui.editors.featuremodel.operations;
 
 import static de.ovgu.featureide.fm.core.localization.StringTable.COLLAPSE_ALL;
+import static de.ovgu.featureide.fm.core.localization.StringTable.EXPAND_ALL;
 
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -47,7 +48,7 @@ public class CollapseAllOperation extends AbstractGraphicalFeatureModelOperation
 	private final LinkedList<IGraphicalFeature> affectedFeatureList = new LinkedList<>();
 
 	public CollapseAllOperation(IGraphicalFeatureModel graphicalFeatureModel, boolean collapse) {
-		super(graphicalFeatureModel, COLLAPSE_ALL);
+		super(graphicalFeatureModel, collapse ? COLLAPSE_ALL : EXPAND_ALL);
 		this.collapse = collapse;
 	}
 

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/outline/custom/Outline.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/outline/custom/Outline.java
@@ -476,7 +476,9 @@ public class Outline extends ViewPart implements ISelectionChangedListener, ITre
 									viewer.setContentProvider(provider.getTreeProvider());
 									viewer.setLabelProvider(provider.getLabelProvider());
 									if (iFile != null) {
-										viewer.setInput(iFile);
+										if (viewer.getInput() != iFile) {
+											viewer.setInput(iFile);
+										}
 										provider.handleUpdate(viewer, iFile);
 										fillLocalToolBar(getViewSite().getActionBars().getToolBarManager());
 										fillContextMenu();
@@ -484,7 +486,6 @@ public class Outline extends ViewPart implements ISelectionChangedListener, ITre
 									viewer.getControl().setRedraw(true);
 									viewer.getControl().setEnabled(true);
 									viewer.refresh();
-									viewer.expandAll();
 								}
 							}
 							return Status.OK_STATUS;

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/outline/custom/Outline.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/outline/custom/Outline.java
@@ -475,13 +475,13 @@ public class Outline extends ViewPart implements ISelectionChangedListener, ITre
 									viewer.getControl().setRedraw(false);
 									viewer.setContentProvider(provider.getTreeProvider());
 									viewer.setLabelProvider(provider.getLabelProvider());
+									fillLocalToolBar(getViewSite().getActionBars().getToolBarManager());
+									fillContextMenu();
 									if (iFile != null) {
 										if (viewer.getInput() != iFile) {
 											viewer.setInput(iFile);
 										}
 										provider.handleUpdate(viewer, iFile);
-										fillLocalToolBar(getViewSite().getActionBars().getToolBarManager());
-										fillContextMenu();
 									}
 									viewer.getControl().setRedraw(true);
 									viewer.getControl().setEnabled(true);

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/outline/custom/OutlineProvider.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/outline/custom/OutlineProvider.java
@@ -30,6 +30,7 @@ import org.eclipse.jface.viewers.ISelectionChangedListener;
 import org.eclipse.jface.viewers.ITreeViewerListener;
 import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IViewSite;
 
 import de.ovgu.featureide.fm.core.io.manager.FeatureModelManager;
 import de.ovgu.featureide.fm.ui.views.outline.custom.filters.IOutlineFilter;
@@ -40,6 +41,8 @@ import de.ovgu.featureide.fm.ui.views.outline.custom.filters.IOutlineFilter;
  * {@link OutlineProvider#isSupported} method.
  *
  * @author Christopher Sontag
+ * @author Kevin Jedelhauser
+ * @author Johannes Herschel
  */
 
 public abstract class OutlineProvider implements ISelectionChangedListener, ITreeViewerListener {
@@ -59,6 +62,13 @@ public abstract class OutlineProvider implements ISelectionChangedListener, ITre
 	}
 
 	/**
+	 * Called when the active editor has changed.
+	 *
+	 * @param part The new active editor, null if there is no active editor
+	 */
+	public void setActiveEditor(IEditorPart part) {}
+
+	/**
 	 * Populates the context menu of the outline provider.
 	 *
 	 * @param manager
@@ -71,6 +81,13 @@ public abstract class OutlineProvider implements ISelectionChangedListener, ITre
 	 * @param manager
 	 */
 	protected abstract void initToolbarActions(IToolBarManager manager);
+
+	/**
+	 * Populates the global actions of the outline provider.
+	 *
+	 * @param actionBars
+	 */
+	protected void initGlobalActions(IViewSite site) {}
 
 	/**
 	 * Initalizes a list of {@link IOutlineFilter}} which populate the filter menu. NOTE: The menu is only shown if the filter list is not empty.

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/outline/custom/providers/FMOutlineProvider.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/outline/custom/providers/FMOutlineProvider.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.action.IMenuManager;
 import org.eclipse.jface.action.IToolBarManager;
+import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
 import org.eclipse.jface.viewers.IContentProvider;
 import org.eclipse.jface.viewers.SelectionChangedEvent;
@@ -132,6 +133,13 @@ public class FMOutlineProvider extends OutlineProvider implements IEventListener
 	@Override
 	protected void initToolbarActions(IToolBarManager manager) {
 		syncCollapsedStateAction = new SyncCollapsedStateAction();
+		syncCollapsedStateAction.addPropertyChangeListener(new IPropertyChangeListener() {
+
+			@Override
+			public void propertyChange(PropertyChangeEvent event) {
+				setExpandedElements();
+			}
+		});
 		syncCollapsedStateAction.setEnabled(true);
 		manager.add(syncCollapsedStateAction);
 	}
@@ -142,14 +150,16 @@ public class FMOutlineProvider extends OutlineProvider implements IEventListener
 	}
 
 	private void setExpandedElements() {
-		final ArrayList<Object> expandedElements = new ArrayList<>();
-		for (final IGraphicalFeature f : graphicalFeatureModel.getAllFeatures()) {
-			if (!f.isCollapsed()) {
-				expandedElements.add(f);
+		if (syncCollapsedStateAction.isChecked()) {
+			final ArrayList<Object> expandedElements = new ArrayList<>();
+			for (final IGraphicalFeature f : graphicalFeatureModel.getAllFeatures()) {
+				if (!f.isCollapsed()) {
+					expandedElements.add(f.getObject());
+				}
 			}
+			expandedElements.add("Constraints");
+			viewer.setExpandedElements(expandedElements.toArray());
 		}
-		expandedElements.add("Constraints");
-		viewer.setExpandedElements(expandedElements.toArray());
 	}
 
 	@Override

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/outline/custom/providers/FMOutlineProvider.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/outline/custom/providers/FMOutlineProvider.java
@@ -44,15 +44,14 @@ import org.eclipse.ui.operations.RedoActionHandler;
 import org.eclipse.ui.operations.UndoActionHandler;
 
 import de.ovgu.featureide.fm.core.base.IFeature;
-import de.ovgu.featureide.fm.core.base.IFeatureModel;
 import de.ovgu.featureide.fm.core.base.event.FeatureIDEEvent;
-import de.ovgu.featureide.fm.core.base.event.FeatureIDEEvent.EventType;
 import de.ovgu.featureide.fm.core.base.event.IEventListener;
 import de.ovgu.featureide.fm.core.base.impl.FMFormatManager;
 import de.ovgu.featureide.fm.core.io.EclipseFileSystem;
 import de.ovgu.featureide.fm.ui.editors.FeatureModelEditor;
 import de.ovgu.featureide.fm.ui.editors.IGraphicalFeature;
 import de.ovgu.featureide.fm.ui.editors.IGraphicalFeatureModel;
+import de.ovgu.featureide.fm.ui.editors.featuremodel.operations.CollapseAllOperation;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.operations.CollapseFeatureOperation;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.operations.FeatureModelOperationWrapper;
 import de.ovgu.featureide.fm.ui.views.outline.FmOutlinePageContextMenu;
@@ -240,24 +239,14 @@ public class FMOutlineProvider extends OutlineProvider implements IEventListener
 	@Override
 	public void handleExpandAll(PropertyChangeEvent event) {
 		if (syncCollapsedStateAction.isChecked()) {
-			final IFeatureModel featureModel = featureModelManager.getSnapshot();
-			for (final IFeature f : featureModel.getFeatures()) {
-				graphicalFeatureModel.getGraphicalFeature(f).setCollapsed(false);
-			}
-			featureModelManager.fireEvent(new FeatureIDEEvent(featureModel.getFeatures().iterator(), EventType.FEATURE_COLLAPSED_ALL_CHANGED));
+			FeatureModelOperationWrapper.run(new CollapseAllOperation(graphicalFeatureModel, false));
 		}
 	}
 
 	@Override
 	public void handleCollapseAll(PropertyChangeEvent event) {
 		if (syncCollapsedStateAction.isChecked()) {
-			final IFeatureModel featureModel = featureModelManager.getSnapshot();
-			for (final IFeature f : featureModel.getFeatures()) {
-				if (!f.getStructure().isRoot()) {
-					graphicalFeatureModel.getGraphicalFeature(f).setCollapsed(true);
-				}
-			}
-			featureModelManager.fireEvent(new FeatureIDEEvent(featureModel.getFeatures().iterator(), EventType.FEATURE_COLLAPSED_ALL_CHANGED));
+			FeatureModelOperationWrapper.run(new CollapseAllOperation(graphicalFeatureModel, true));
 		}
 	}
 

--- a/plugins/de.ovgu.featureide.ui/src/de/ovgu/featureide/ui/views/configMap/ConfigurationMap.java
+++ b/plugins/de.ovgu.featureide.ui/src/de/ovgu/featureide/ui/views/configMap/ConfigurationMap.java
@@ -69,6 +69,7 @@ import de.ovgu.featureide.fm.core.color.FeatureColorManager;
 import de.ovgu.featureide.fm.core.configuration.Configuration;
 import de.ovgu.featureide.fm.core.configuration.io.ConfigurationLoader;
 import de.ovgu.featureide.fm.core.configuration.io.IConfigurationLoaderCallback;
+import de.ovgu.featureide.fm.ui.editors.FeatureModelEditor;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.actions.colors.SetFeatureColorAction;
 import de.ovgu.featureide.ui.UIPlugin;
 import de.ovgu.featureide.ui.views.configMap.actions.ConfigMapFilterMenuAction;
@@ -613,6 +614,12 @@ public class ConfigurationMap extends ViewPart implements ICustomTableHeaderSele
 					if ((newProject != null) && !newProject.equals(featureProject)) {
 						setFeatureProject(newProject);
 						isNew = true;
+					} else if ((newProject == null) && (newEditor instanceof FeatureModelEditor)) {
+						// if there was a project opened in a featuremodeleditor that is not a featureide project
+						if (newProject != featureProject) {
+							setFeatureProject(newProject);
+							refresh();
+						}
 					}
 				}
 				final Object[] expandedElements = tree.getExpandedElements();
@@ -624,6 +631,10 @@ public class ConfigurationMap extends ViewPart implements ICustomTableHeaderSele
 					tree.expandAll();
 				}
 			}
+		} else {
+			// refresh configuration map when closig all editors
+			setFeatureProject(null);
+			refresh();
 		}
 
 		currentEditor = newEditor;

--- a/plugins/de.ovgu.featureide.ui/src/de/ovgu/featureide/ui/views/configMap/ConfigurationMapTreeContentProvider.java
+++ b/plugins/de.ovgu.featureide.ui/src/de/ovgu/featureide/ui/views/configMap/ConfigurationMapTreeContentProvider.java
@@ -40,7 +40,7 @@ import de.ovgu.featureide.fm.core.localization.StringTable;
  */
 public class ConfigurationMapTreeContentProvider implements ITreeContentProvider, IConfigurationMapFilterable {
 
-	private static final Object[] emptyRoot = new Object[] { StringTable.PLEASE_OPEN_A_FEATURE_DIAGRAM_EDITOR };
+	private static final Object[] emptyRoot = new Object[] { StringTable.PLEASE_OPEN_A_FEATUREIDE_PROJECT };
 
 	private IFeatureProject featureProject;
 	private Object[] featureRoots = emptyRoot;


### PR DESCRIPTION
Fixes #1005 and some other issues with the FeatureIDE Outline.

- Fixes synchronization of collapsed features of the outline with the feature model editor.
- Fixes an issue where the outline remains completely empty when no editor is opened (not even showing the "not available" message)
- Fixes an issue where the outline does not refresh when switching the active editor.
- Adds undo/redo for collapsing/expanding features in the outline.