### PR TITLE
Issue #1151

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/elements/GraphicalFeatureModel.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/elements/GraphicalFeatureModel.java
@@ -374,6 +374,7 @@ public class GraphicalFeatureModel implements IGraphicalFeatureModel {
 		switch (fm.getProperty().get(LAYOUT, TYPE_GRAPHICS, VALUE_HORIZONTAL)) {
 		case VALUE_VERTICAL:
 			getLayout().setVerticalLayout(true);
+			break;
 		case VALUE_HORIZONTAL:
 		default:
 			getLayout().setVerticalLayout(false);

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/figures/CollapsedDecoration.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/figures/CollapsedDecoration.java
@@ -97,10 +97,13 @@ public class CollapsedDecoration extends ConnectionDecoration implements GUIDefa
 		}
 
 		if (graphicalFeature != null) {
+			// Calculate layout direction
 			final FeatureModelLayout layout = graphicalFeature.getGraphicalModel().getLayout();
 			final Configuration.Location rootPosition = layout.isUsesAbegoTreeLayout() ? layout.getAbegoRootposition()
 				: (layout.hasVerticalLayout() ? Configuration.Location.Left : Configuration.Location.Top);
 
+			// Apply offset to center the decoration box along the appropriate edge of the graphical feature and take
+			// GUIDefaults.COLLAPSED_DECORATOR_FEATURE_SPACE into account
 			switch (rootPosition) {
 			case Top:
 				super.setLocation(p.translate(-getBounds().width / 2, GUIDefaults.COLLAPSED_DECORATOR_FEATURE_SPACE));

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/figures/CollapsedDecoration.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/figures/CollapsedDecoration.java
@@ -20,6 +20,7 @@
  */
 package de.ovgu.featureide.fm.ui.editors.featuremodel.figures;
 
+import org.abego.treelayout.Configuration;
 import org.eclipse.draw2d.FreeformLayout;
 import org.eclipse.draw2d.Graphics;
 import org.eclipse.draw2d.Label;
@@ -95,34 +96,24 @@ public class CollapsedDecoration extends ConnectionDecoration implements GUIDefa
 			return;
 		}
 
-		super.setLocation(p.translate(-(getBounds().width / 2) + GUIDefaults.COLLAPSED_DECORATOR_FEATURE_SPACE, GUIDefaults.COLLAPSED_DECORATOR_FEATURE_SPACE));
-
 		if (graphicalFeature != null) {
 			final FeatureModelLayout layout = graphicalFeature.getGraphicalModel().getLayout();
-			// set Collapse position for abego treeLayout
-			if (layout.isUsesAbegoTreeLayout()) {
-				switch (layout.getAbegoRootposition()) {
-				case Left:
-					super.setLocation(super.getLocation().translate((+getBounds().width / 2) + GUIDefaults.COLLAPSED_DECORATOR_FEATURE_SPACE,
-							(-getBounds().height / 2) + 1));
-					break;
-				case Right:
-					super.setLocation(super.getLocation().translate((-getBounds().width / 2) - GUIDefaults.COLLAPSED_DECORATOR_FEATURE_SPACE,
-							(-getBounds().height / 2) + 1));
-					break;
-				case Bottom:
-					super.setLocation(super.getLocation().translate(0, (-getBounds().height) + 1));
-					break;
-				default:
-					// Same as default
-					break;
-				}
-			} else {
-				if (graphicalFeature.getGraphicalModel().getLayout().hasVerticalLayout()) {
-					// left to right layout
-					super.setLocation(super.getLocation().translate((+getBounds().width / 2) + GUIDefaults.COLLAPSED_DECORATOR_FEATURE_SPACE,
-							(-getBounds().height / 2) + 1));
-				}
+			final Configuration.Location rootPosition = layout.isUsesAbegoTreeLayout() ? layout.getAbegoRootposition()
+				: (layout.hasVerticalLayout() ? Configuration.Location.Left : Configuration.Location.Top);
+
+			switch (rootPosition) {
+			case Top:
+				super.setLocation(p.translate(-getBounds().width / 2, GUIDefaults.COLLAPSED_DECORATOR_FEATURE_SPACE));
+				break;
+			case Left:
+				super.setLocation(p.translate(GUIDefaults.COLLAPSED_DECORATOR_FEATURE_SPACE, -getBounds().height / 2));
+				break;
+			case Right:
+				super.setLocation(p.translate(-getBounds().width - GUIDefaults.COLLAPSED_DECORATOR_FEATURE_SPACE, -getBounds().height / 2));
+				break;
+			case Bottom:
+				super.setLocation(p.translate(-getBounds().width / 2, -getBounds().height - GUIDefaults.COLLAPSED_DECORATOR_FEATURE_SPACE));
+				break;
 			}
 		}
 	}

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/figures/CollapsedDecoration.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/figures/CollapsedDecoration.java
@@ -118,7 +118,7 @@ public class CollapsedDecoration extends ConnectionDecoration implements GUIDefa
 					break;
 				}
 			} else {
-				if (graphicalFeature.getGraphicalModel().getLayout().getLayoutAlgorithm() == 4) {
+				if (graphicalFeature.getGraphicalModel().getLayout().hasVerticalLayout()) {
 					// left to right layout
 					super.setLocation(super.getLocation().translate((+getBounds().width / 2) + GUIDefaults.COLLAPSED_DECORATOR_FEATURE_SPACE,
 							(-getBounds().height / 2) + 1));


### PR DESCRIPTION
Improvements regarding #1151.

- Task 1: Fixed, along with minor positioning issues in other layouts and some code clean up.
- Task 2: Not fixed.
- Task 3: Partially fixed. This still occurs when selecting one of the abego layouts with bottom or right root position, then selecting manual layout, then reopening the model.

Fixing tasks 2 (a) and 3 would require changes to the model file format. Task 2 (a) requires storing locations of collapsed features in automatic layouts, and fixing task 3 requires storing the abego layout type in case of the manual layout. Task 2 (b) could be fixed by calculating the layout of collapsed features, but this would have a negative performance impact, and could also negatively affect the layout of visible features.
These changes were considered unreasonable due to their small benefits.