### PR TITLE
No movement of features from external models

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/commands/FeatureDragAndDropCommand.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/commands/FeatureDragAndDropCommand.java
@@ -24,6 +24,7 @@ import org.eclipse.draw2d.geometry.Dimension;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.gef.commands.Command;
 
+import de.ovgu.featureide.fm.core.base.impl.MultiFeature;
 import de.ovgu.featureide.fm.ui.editors.FeatureUIHelper;
 import de.ovgu.featureide.fm.ui.editors.IGraphicalFeature;
 import de.ovgu.featureide.fm.ui.editors.IGraphicalFeatureModel;
@@ -105,6 +106,11 @@ public class FeatureDragAndDropCommand extends Command {
 			}
 
 			if (FeatureUIHelper.isAncestorOf(newParent, feature)) {
+				return false;
+			}
+
+			// no moving of feature from external submodel
+			if ((feature != null) && (feature.getObject() instanceof MultiFeature) && ((MultiFeature) feature.getObject()).isFromExtern()) {
 				return false;
 			}
 		}

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/commands/FeatureDragAndDropCommand.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/commands/FeatureDragAndDropCommand.java
@@ -110,11 +110,20 @@ public class FeatureDragAndDropCommand extends Command {
 			}
 
 			// no moving of feature from external submodel
-			if ((feature != null) && (feature.getObject() instanceof MultiFeature) && ((MultiFeature) feature.getObject()).isFromExtern()) {
+			if (isFeatureFromSubmodel(feature) && ((MultiFeature) feature.getObject().getStructure().getParent().getFeature()).isFromExtern()) {
+				return false;
+			}
+
+			// no moving under a feature from external submodel
+			if (isFeatureFromSubmodel(newParent)) {
 				return false;
 			}
 		}
 		return true;
+	}
+
+	private boolean isFeatureFromSubmodel(IGraphicalFeature feature) {
+		return (feature != null) && (feature.getObject() instanceof MultiFeature) && ((MultiFeature) feature.getObject()).isFromExtern();
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #1175 

Only allow moving of external features at the root feature for moving the whole subtree. Otherwise, no movement of/under a feature from an external model.