### PR TITLE
Completed issue 1143

### DIFF
--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/IFeatureModelFormat.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/IFeatureModelFormat.java
@@ -27,7 +27,7 @@ import de.ovgu.featureide.fm.core.base.IFeatureModel;
  *
  * @author Sebastian Krieter
  */
-public interface IFeatureModelFormat extends IPersistentFormat<IFeatureModel> {
+public interface IFeatureModelFormat extends IPersistentFormat<IFeatureModel>, IFeatureNameValidator {
 
 	public static String extensionPointID = "FMFormat";
 
@@ -39,5 +39,10 @@ public interface IFeatureModelFormat extends IPersistentFormat<IFeatureModel> {
 	void setFeatureNameValidator(IFeatureNameValidator validator);
 
 	IFeatureNameValidator getFeatureNameValidator();
+	
+	@Override
+	default boolean isValidFeatureName(String featureName) {
+		return true;
+	}
 
 }

--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/IFeatureNameValidator.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/IFeatureNameValidator.java
@@ -35,4 +35,8 @@ public interface IFeatureNameValidator {
 	 */
 	boolean isValidFeatureName(String featureName);
 
+	default String getErrorMessage() {
+		return "";
+	}
+
 }

--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
@@ -506,6 +506,16 @@ public class UVLFeatureModelFormat extends AFeatureModelFormat {
 	}
 
 	@Override
+	public boolean isValidFeatureName(String featureName) {
+		return featureName.matches("[^\\\"\\.\\n\\r]*");
+	}
+
+	@Override
+	public String getErrorMessage() {
+		return "The characters  \" and . are not allowed and the feature name has to be non-empty.";
+	}
+
+	@Override
 	public boolean initExtension() {
 		FMFactoryManager.getInstance().getDefaultFactoryWorkspace().assignID(getId(), MultiFeatureModelFactory.ID);
 		return super.initExtension();

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/commands/FeatureRenamingCommand.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/commands/FeatureRenamingCommand.java
@@ -34,7 +34,10 @@ import de.ovgu.featureide.fm.core.IFMComposerExtension;
 import de.ovgu.featureide.fm.core.base.FeatureUtils;
 import de.ovgu.featureide.fm.core.base.IFeatureModel;
 import de.ovgu.featureide.fm.core.functional.Functional;
+import de.ovgu.featureide.fm.core.io.IFeatureModelFormat;
+import de.ovgu.featureide.fm.core.io.IPersistentFormat;
 import de.ovgu.featureide.fm.core.io.manager.IFeatureModelManager;
+import de.ovgu.featureide.fm.core.io.manager.IFileManager;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.operations.FeatureModelOperationWrapper;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.operations.RenameFeatureOperation;
 
@@ -76,6 +79,12 @@ public class FeatureRenamingCommand extends Command {
 				final IFile sourceFile = ResourcesPlugin.getWorkspace().getRoot().findFilesForLocationURI(sourceUri)[0];
 				if (sourceFile != null) {
 					final IFMComposerExtension fmComposerExtension = FMComposerManager.getFMComposerExtension(sourceFile.getProject());
+					if (featureModelManager instanceof IFileManager) {
+						final IPersistentFormat<?> format = ((IFileManager<?>) featureModelManager).getFormat();
+						if ((format instanceof IFeatureModelFormat) && !((IFeatureModelFormat) format).isValidFeatureName(newName)) {
+							return false;
+						}
+					}
 					return (fmComposerExtension != null) && fmComposerExtension.isValidFeatureName(newName);
 				}
 			}

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/commands/renaming/FeatureLabelEditManager.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/commands/renaming/FeatureLabelEditManager.java
@@ -40,6 +40,9 @@ import de.ovgu.featureide.fm.core.IFMComposerExtension;
 import de.ovgu.featureide.fm.core.base.FeatureUtils;
 import de.ovgu.featureide.fm.core.base.IFeatureModel;
 import de.ovgu.featureide.fm.core.functional.Functional;
+import de.ovgu.featureide.fm.core.io.IFeatureModelFormat;
+import de.ovgu.featureide.fm.core.io.IPersistentFormat;
+import de.ovgu.featureide.fm.core.io.manager.IFileManager;
 import de.ovgu.featureide.fm.core.io.manager.IManager;
 import de.ovgu.featureide.fm.ui.editors.FeatureDiagramViewer;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.GUIDefaults;
@@ -97,9 +100,19 @@ public class FeatureLabelEditManager extends DirectEditManager implements GUIDef
 						final IProject project =
 							ResourcesPlugin.getWorkspace().getRoot().getFileForLocation(new Path(featureModel.getSourceFile().toString())).getProject();
 						final IFMComposerExtension fmComposerExtension = FMComposerManager.getFMComposerExtension(project);
-						if ((!fmComposerExtension.isValidFeatureName(value))) {
+
+						if (!fmComposerExtension.isValidFeatureName(value)) {
 							createTooltip(fmComposerExtension.getErrorMessage(), SWT.ICON_ERROR);
 						} else {
+							if (featureModelManager instanceof IFileManager) {
+								final IPersistentFormat<?> format = ((IFileManager<?>) featureModelManager).getFormat();
+								if (format instanceof IFeatureModelFormat) {
+									if (!((IFeatureModelFormat) format).isValidFeatureName(value)) {
+										createTooltip(((IFeatureModelFormat) format).getErrorMessage(), SWT.ICON_ERROR);
+										return;
+									}
+								}
+							}
 							final Iterable<String> extractFeatureNames;
 							extractFeatureNames = FeatureUtils.extractFeatureNames(featureModel.getFeatures());
 							if (Functional.toList(extractFeatureNames).contains(value)) {


### PR DESCRIPTION
Fixed #1143

Adjusted UVL parser to support less restrictive feature names.
Feature names may now include any character, except " (quotes) and .
(dots).
If a feature name contains white spaces, the feature name is surrounded
by quotes.
When a UVL model file is parsed, quotes are removed. When a UVL model is
printed to a file, quotes are pre- and appended when needed.

The error message in the tool tip also has been adjusted.