### PR TITLE
Toggle instead of automatically let constraints disappear

### DIFF
--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/localization/StringTable.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/localization/StringTable.java
@@ -1148,4 +1148,5 @@ public class StringTable {
 	public static final String SHOW = "Show";
 	public static final String SHOW_ALL_LEVELS = "Show All Levels";
 	public static final String SHA_256_DIGEST_ALGORITHM = "SHA-256";
+	public static final String SHOW_CONSTRAINTS = "Show Constraints";
 }

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramEditor.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureDiagramEditor.java
@@ -151,6 +151,7 @@ import de.ovgu.featureide.fm.ui.editors.featuremodel.actions.ReverseOrderAction;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.actions.SelectSubtreeAction;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.actions.SelectionAction;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.actions.ShowCollapsedConstraintsAction;
+import de.ovgu.featureide.fm.ui.editors.featuremodel.actions.ShowConstraintsAction;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.actions.calculations.AutomatedCalculationsAction;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.actions.calculations.ConstrainsCalculationsAction;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.actions.calculations.FeaturesOnlyCalculationAction;
@@ -214,6 +215,7 @@ public class FeatureDiagramEditor extends FeatureModelEditorPage implements GUID
 	private MoveAction moveDownAction;
 	private MoveAction moveLeftAction;
 
+	private ShowConstraintsAction showConstraintsAction;
 	private ShowCollapsedConstraintsAction showCollapsedConstraintsAction;
 
 	private ZoomInAction zoomIn;
@@ -332,6 +334,7 @@ public class FeatureDiagramEditor extends FeatureModelEditorPage implements GUID
 		zoomOut = addAction(new ZoomOutAction(viewer.getZoomManager()));
 
 		// Layout actions
+		showConstraintsAction = addAction(new ShowConstraintsAction(viewer, graphicalFeatureModel));
 		autoLayoutConstraintAction = addAction(new AutoLayoutConstraintAction(viewer, graphicalFeatureModel));
 		setLayoutActions = new ArrayList<>(FeatureDiagramLayoutHelper.NUMBER_OF_LAYOUT_ALGORITHMS);
 		for (int i = 0; i < FeatureDiagramLayoutHelper.NUMBER_OF_LAYOUT_ALGORITHMS; i++) {
@@ -1327,6 +1330,8 @@ public class FeatureDiagramEditor extends FeatureModelEditorPage implements GUID
 			menuManager.add(createCalculationsMenuManager(true));
 			menuManager.add(new Separator());
 			menuManager.add(reverseOrderAction);
+			menuManager.add(showConstraintsAction);
+			showConstraintsAction.setChecked(!graphicalFeatureModel.getConstraintsHidden());
 			// only show the "Show Collapsed Constraints"-entry when the constraints are visible in the diagram editor
 			if (!graphicalFeatureModel.getConstraintsHidden()) {
 				menuManager.add(showCollapsedConstraintsAction);

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/elements/GraphicalFeatureModel.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/elements/GraphicalFeatureModel.java
@@ -387,7 +387,7 @@ public class GraphicalFeatureModel implements IGraphicalFeatureModel {
 		getLayout().showCollapsedConstraints(colapsedConstraints != null ? colapsedConstraints : true);
 
 		final Boolean showConstraints = FeatureModelProperty.getBooleanProperty(fm.getProperty(), TYPE_GRAPHICS, SHOW_CONSTRAINTS);
-		setConstraintsHidden(showConstraints);
+		setConstraintsHidden(showConstraints != null ? showConstraints : false);
 
 		final Boolean legendHidden = FeatureModelProperty.getBooleanProperty(fm.getProperty(), TYPE_GRAPHICS, LEGEND_HIDDEN);
 		setLegendHidden(legendHidden != null ? legendHidden : false);

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/elements/GraphicalFeatureModel.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/elements/GraphicalFeatureModel.java
@@ -349,6 +349,7 @@ public class GraphicalFeatureModel implements IGraphicalFeatureModel {
 	}
 
 	private static final String LAYOUT_ALGORITHM = "layoutalgorithm";
+	private static final String SHOW_CONSTRAINTS = "showconstraints";
 	private static final String SHOW_COLLAPSED_CONSTRAINTS = "showcollapsedconstraints";
 	private static final String SHOW_SHORT_NAMES = "showshortnames";
 	private static final String LEGEND_AUTO_LAYOUT = "legendautolayout";
@@ -384,6 +385,9 @@ public class GraphicalFeatureModel implements IGraphicalFeatureModel {
 
 		final Boolean colapsedConstraints = FeatureModelProperty.getBooleanProperty(fm.getProperty(), TYPE_GRAPHICS, SHOW_COLLAPSED_CONSTRAINTS);
 		getLayout().showCollapsedConstraints(colapsedConstraints != null ? colapsedConstraints : true);
+
+		final Boolean showConstraints = FeatureModelProperty.getBooleanProperty(fm.getProperty(), TYPE_GRAPHICS, SHOW_CONSTRAINTS);
+		setConstraintsHidden(showConstraints);
 
 		final Boolean legendHidden = FeatureModelProperty.getBooleanProperty(fm.getProperty(), TYPE_GRAPHICS, LEGEND_HIDDEN);
 		setLegendHidden(legendHidden != null ? legendHidden : false);
@@ -518,6 +522,11 @@ public class GraphicalFeatureModel implements IGraphicalFeatureModel {
 			fm.getProperty().set(SHOW_SHORT_NAMES, TYPE_GRAPHICS, FeatureModelProperty.VALUE_BOOLEAN_TRUE);
 		} else {
 			fm.getProperty().set(SHOW_SHORT_NAMES, TYPE_GRAPHICS, FeatureModelProperty.VALUE_BOOLEAN_FALSE);
+		}
+		if (getLayout().showConstraints()) {
+			fm.getProperty().set(SHOW_CONSTRAINTS, TYPE_GRAPHICS, FeatureModelProperty.VALUE_BOOLEAN_TRUE);
+		} else {
+			fm.getProperty().set(SHOW_CONSTRAINTS, TYPE_GRAPHICS, FeatureModelProperty.VALUE_BOOLEAN_FALSE);
 		}
 		if (getLayout().showCollapsedConstraints()) {
 			fm.getProperty().set(SHOW_COLLAPSED_CONSTRAINTS, TYPE_GRAPHICS, FeatureModelProperty.VALUE_BOOLEAN_TRUE);

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/elements/GraphicalFeatureModel.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/elements/GraphicalFeatureModel.java
@@ -387,7 +387,7 @@ public class GraphicalFeatureModel implements IGraphicalFeatureModel {
 		getLayout().showCollapsedConstraints(colapsedConstraints != null ? colapsedConstraints : true);
 
 		final Boolean showConstraints = FeatureModelProperty.getBooleanProperty(fm.getProperty(), TYPE_GRAPHICS, SHOW_CONSTRAINTS);
-		setConstraintsHidden(showConstraints != null ? showConstraints : false);
+		setConstraintsHidden(showConstraints != null ? !showConstraints : false);
 
 		final Boolean legendHidden = FeatureModelProperty.getBooleanProperty(fm.getProperty(), TYPE_GRAPHICS, LEGEND_HIDDEN);
 		setLegendHidden(legendHidden != null ? legendHidden : false);

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/ShowConstraintsAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/ShowConstraintsAction.java
@@ -1,0 +1,54 @@
+/* FeatureIDE - A Framework for Feature-Oriented Software Development
+ * Copyright (C) 2005-2017  FeatureIDE team, University of Magdeburg, Germany
+ *
+ * This file is part of FeatureIDE.
+ *
+ * FeatureIDE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * FeatureIDE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with FeatureIDE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See http://featureide.cs.ovgu.de/ for further information.
+ */
+package de.ovgu.featureide.fm.ui.editors.featuremodel.actions;
+
+import static de.ovgu.featureide.fm.core.localization.StringTable.SHOW_CONSTRAINTS;
+
+import org.eclipse.gef.ui.parts.GraphicalViewerImpl;
+import org.eclipse.jface.action.Action;
+
+import de.ovgu.featureide.fm.ui.editors.IGraphicalFeatureModel;
+import de.ovgu.featureide.fm.ui.editors.featuremodel.operations.FeatureModelOperationWrapper;
+import de.ovgu.featureide.fm.ui.editors.featuremodel.operations.ShowConstraintsOperation;
+
+/**
+ * Action to show/hide constraints beneath the feature model
+ *
+ * @author Rahel Arens
+ */
+public class ShowConstraintsAction extends Action {
+
+	public static final String ID = "de.ovgu.featureide.hideconstraints";
+
+	private final IGraphicalFeatureModel featureModel;
+
+	public ShowConstraintsAction(GraphicalViewerImpl viewer, IGraphicalFeatureModel featureModel) {
+		super(SHOW_CONSTRAINTS);
+		this.featureModel = featureModel;
+		setId(ID);
+	}
+
+	@Override
+	public void run() {
+		FeatureModelOperationWrapper.run(new ShowConstraintsOperation(featureModel));
+	}
+
+}

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/layouts/FeatureModelLayout.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/layouts/FeatureModelLayout.java
@@ -34,6 +34,7 @@ public class FeatureModelLayout implements IExtendedFeatureModelLayout {
 	private Configuration.Location abegoRootposition;
 
 	private boolean autoLayoutLegend;
+	private boolean showConstraints;
 	private boolean showCollapsedConstraints;
 	private boolean hasVerticalLayout;
 	private final Point legendPos;
@@ -52,6 +53,7 @@ public class FeatureModelLayout implements IExtendedFeatureModelLayout {
 		selectedLayoutAlgorithm = 4;
 		usesAbegoTreeLayout = false;
 		autoLayoutConstraints = false;
+		showConstraints = true;
 	}
 
 	protected FeatureModelLayout(FeatureModelLayout featureModelLayout) {
@@ -62,6 +64,7 @@ public class FeatureModelLayout implements IExtendedFeatureModelLayout {
 		selectedLayoutAlgorithm = featureModelLayout.selectedLayoutAlgorithm;
 		usesAbegoTreeLayout = featureModelLayout.usesAbegoTreeLayout;
 		autoLayoutConstraints = featureModelLayout.autoLayoutConstraints;
+		showConstraints = true;
 	}
 
 	public boolean isAutoLayoutConstraints() {
@@ -90,6 +93,16 @@ public class FeatureModelLayout implements IExtendedFeatureModelLayout {
 	@Override
 	public void setShowShortNames(boolean b) {
 		showShortNames = b;
+	}
+
+	@Override
+	public boolean showConstraints() {
+		return showConstraints;
+	}
+
+	@Override
+	public void showConstraints(boolean b) {
+		showConstraints = b;
 	}
 
 	@Override

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/layouts/IFeatureModelLayout.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/layouts/IFeatureModelLayout.java
@@ -26,6 +26,10 @@ public interface IFeatureModelLayout {
 
 	public boolean hasLegendAutoLayout();
 
+	public boolean showConstraints();
+
+	public void showConstraints(boolean b);
+
 	public boolean showCollapsedConstraints();
 
 	public void showCollapsedConstraints(boolean b);

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/operations/ShowConstraintsOperation.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/operations/ShowConstraintsOperation.java
@@ -41,6 +41,7 @@ public class ShowConstraintsOperation extends AbstractGraphicalFeatureModelOpera
 	@Override
 	protected FeatureIDEEvent operation(IFeatureModel featureModel) {
 		graphicalFeatureModel.setConstraintsHidden(!graphicalFeatureModel.getConstraintsHidden());
+		graphicalFeatureModel.getLayout().showConstraints(graphicalFeatureModel.getConstraintsHidden());
 		return new FeatureIDEEvent(graphicalFeatureModel, EventType.MODEL_LAYOUT_CHANGED);
 	}
 

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/operations/ShowConstraintsOperation.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/operations/ShowConstraintsOperation.java
@@ -1,0 +1,52 @@
+/* FeatureIDE - A Framework for Feature-Oriented Software Development
+ * Copyright (C) 2005-2017  FeatureIDE team, University of Magdeburg, Germany
+ *
+ * This file is part of FeatureIDE.
+ *
+ * FeatureIDE is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * FeatureIDE is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with FeatureIDE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * See http://featureide.cs.ovgu.de/ for further information.
+ */
+package de.ovgu.featureide.fm.ui.editors.featuremodel.operations;
+
+import static de.ovgu.featureide.fm.core.localization.StringTable.SHOW_CONSTRAINTS;
+
+import de.ovgu.featureide.fm.core.base.IFeatureModel;
+import de.ovgu.featureide.fm.core.base.event.FeatureIDEEvent;
+import de.ovgu.featureide.fm.core.base.event.FeatureIDEEvent.EventType;
+import de.ovgu.featureide.fm.ui.editors.IGraphicalFeatureModel;
+
+/**
+ * Specifies whether constraints are shown beneath the feature model.
+ *
+ * @author Rahel Arens
+ */
+public class ShowConstraintsOperation extends AbstractGraphicalFeatureModelOperation {
+
+	public ShowConstraintsOperation(IGraphicalFeatureModel graphicalFeatureModel) {
+		super(graphicalFeatureModel, SHOW_CONSTRAINTS);
+	}
+
+	@Override
+	protected FeatureIDEEvent operation(IFeatureModel featureModel) {
+		graphicalFeatureModel.setConstraintsHidden(!graphicalFeatureModel.getConstraintsHidden());
+		return new FeatureIDEEvent(graphicalFeatureModel, EventType.MODEL_LAYOUT_CHANGED);
+	}
+
+	@Override
+	protected FeatureIDEEvent inverseOperation(IFeatureModel featureModel) {
+		return operation(featureModel);
+	}
+
+}

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/operations/ShowConstraintsOperation.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/operations/ShowConstraintsOperation.java
@@ -41,7 +41,7 @@ public class ShowConstraintsOperation extends AbstractGraphicalFeatureModelOpera
 	@Override
 	protected FeatureIDEEvent operation(IFeatureModel featureModel) {
 		graphicalFeatureModel.setConstraintsHidden(!graphicalFeatureModel.getConstraintsHidden());
-		graphicalFeatureModel.getLayout().showConstraints(graphicalFeatureModel.getConstraintsHidden());
+		graphicalFeatureModel.getLayout().showConstraints(!graphicalFeatureModel.getConstraintsHidden());
 		return new FeatureIDEEvent(graphicalFeatureModel, EventType.MODEL_LAYOUT_CHANGED);
 	}
 

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/ConstraintViewController.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/ConstraintViewController.java
@@ -263,7 +263,6 @@ public class ConstraintViewController extends ViewPart implements GUIDefaults {
 		final boolean constraintsListVisible = isConstraintsListVisible();
 
 		settingsMenu.setStateOfActions(constraintsListVisible && constraintsViewVisible);
-		setConstraintsHidden(featureModelEditor, constraintsViewVisible);
 		updateUndoRedoActions();
 
 		if (constraintsViewVisible && constraintsListVisible) {
@@ -322,7 +321,6 @@ public class ConstraintViewController extends ViewPart implements GUIDefaults {
 
 		// remove listeners from previous FeatureModelEditor
 		if (featureModelEditor != null) {
-			setConstraintsHidden(featureModelEditor, false);
 			if (featureModelEditor.diagramEditor != null) {
 				featureModelEditor.diagramEditor.removeSelectionChangedListener(selectionListener);
 			}
@@ -417,24 +415,6 @@ public class ConstraintViewController extends ViewPart implements GUIDefaults {
 	@Override
 	public void setFocus() {
 		constraintView.getViewer().getTree().setFocus();
-	}
-
-	/**
-	 * Sets the constraints to be hidden or shown below the diagram of a FeatureModelEditor.
-	 *
-	 * @param featureModelEditor The FeatureModelEditor which contains the FeatureDiagramEditor in which the constraints are either hidden or not.
-	 * @param hideConstraints True if the constraints are to be hidden. False if the constraints are to be visible.
-	 */
-	public void setConstraintsHidden(FeatureModelEditor featureModelEditor, boolean hideConstraints) {
-		if (featureModelEditor != null) {
-			final IGraphicalFeatureModel graphicalFeatureModel = featureModelEditor.diagramEditor.getGraphicalFeatureModel();
-
-			// only update the model if the new state of hideConstraint is different from the current state
-			if (graphicalFeatureModel.getConstraintsHidden() != hideConstraints) {
-				graphicalFeatureModel.setConstraintsHidden(hideConstraints);
-				graphicalFeatureModel.redrawDiagram();
-			}
-		}
 	}
 
 	/**

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/listener/ConstraintViewPartListener.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/views/constraintview/listener/ConstraintViewPartListener.java
@@ -46,9 +46,7 @@ public class ConstraintViewPartListener implements IPartListener {
 	public void partActivated(IWorkbenchPart part) {
 		updateActiveEditor(part);
 
-		if (!controller.isConstraintsViewVisible()) {
-			controller.setConstraintsHidden(controller.getFeatureModelEditor(), false);
-		} else if (part instanceof ConstraintViewController) {
+		if (part instanceof ConstraintViewController) {
 			controller.refresh();
 			controller.getView().refresh();
 		}


### PR DESCRIPTION
Fixes #1102.

Constraints are now shown beneath the feature diagram regardless to the constraint view. With a toggle in the context menu, one can let the constraints disappear beneath the feature diagram.