### PR TITLE
Issue-1298

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/ConnectionEditPart.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/ConnectionEditPart.java
@@ -152,8 +152,7 @@ public class ConnectionEditPart extends AbstractConnectionEditPart implements GU
 						final Point requestLocation = ((SelectionRequest) request).getLocation();
 						((CircleDecoration) child).translateToRelative(requestLocation);
 						if (decoratorBounds.contains(requestLocation)) {
-							if (!(feature instanceof MultiFeature) || !(((MultiFeature) feature).isFromExtern()
-								&& ((MultiFeature) ((MultiFeature) feature).getStructure().getParent().getFeature()).isFromExtern())) {
+							if (!(feature instanceof MultiFeature) || !(((MultiFeature) feature.getStructure().getParent().getFeature()).isFromExtern())) {
 								if (FeatureModelOperationWrapper
 										.run(new MandatoryFeatureOperation(feature.getName(), FeatureModelManager.getInstance(feature.getFeatureModel())))) {
 									return true;

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/ConnectionEditPart.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/ConnectionEditPart.java
@@ -152,7 +152,8 @@ public class ConnectionEditPart extends AbstractConnectionEditPart implements GU
 						final Point requestLocation = ((SelectionRequest) request).getLocation();
 						((CircleDecoration) child).translateToRelative(requestLocation);
 						if (decoratorBounds.contains(requestLocation)) {
-							if (!(feature instanceof MultiFeature) || !((MultiFeature) feature).isFromExtern()) {
+							if (!(feature instanceof MultiFeature) || !(((MultiFeature) feature).isFromExtern()
+								&& ((MultiFeature) ((MultiFeature) feature).getStructure().getParent().getFeature()).isFromExtern())) {
 								if (FeatureModelOperationWrapper
 										.run(new MandatoryFeatureOperation(feature.getName(), FeatureModelManager.getInstance(feature.getFeatureModel())))) {
 									return true;

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/ConnectionEditPart.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/editparts/ConnectionEditPart.java
@@ -152,9 +152,12 @@ public class ConnectionEditPart extends AbstractConnectionEditPart implements GU
 						final Point requestLocation = ((SelectionRequest) request).getLocation();
 						((CircleDecoration) child).translateToRelative(requestLocation);
 						if (decoratorBounds.contains(requestLocation)) {
-							if (FeatureModelOperationWrapper
-									.run(new MandatoryFeatureOperation(feature.getName(), FeatureModelManager.getInstance(feature.getFeatureModel())))) {
-								return true;
+							if (!(feature instanceof MultiFeature) || !((MultiFeature) feature).isFromExtern()) {
+								if (FeatureModelOperationWrapper
+										.run(new MandatoryFeatureOperation(feature.getName(), FeatureModelManager.getInstance(feature.getFeatureModel())))) {
+									return true;
+								}
+
 							}
 						}
 					}


### PR DESCRIPTION
Fixes #1298.

Before making a feature mandatory/optional, add an additional check for:
1. its not a multifeature
2. if it is a multifeature: if its from a submodel, its parent should not be from a submodel (the feature is the root feature of the imported model).