### PR TITLE
Fixes copyFeature method of feature model factories (#1206)

### DIFF
--- a/plugins/de.ovgu.featureide.fm.attributes/src/de/ovgu/featureide/fm/attributes/base/impl/ExtendedFeatureModelFactory.java
+++ b/plugins/de.ovgu.featureide.fm.attributes/src/de/ovgu/featureide/fm/attributes/base/impl/ExtendedFeatureModelFactory.java
@@ -77,7 +77,7 @@ public class ExtendedFeatureModelFactory implements IFeatureModelFactory {
 
 	@Override
 	public ExtendedFeature copyFeature(IFeatureModel featureModel, IFeature oldFeature) {
-		return (ExtendedFeature) oldFeature.clone(featureModel, oldFeature.getStructure().clone(featureModel));
+		return (ExtendedFeature) oldFeature.getStructure().clone(featureModel).getFeature();
 	}
 
 	@Override

--- a/plugins/de.ovgu.featureide.fm.attributes/src/de/ovgu/featureide/fm/attributes/base/impl/ExtendedMultiFeatureModelFactory.java
+++ b/plugins/de.ovgu.featureide.fm.attributes/src/de/ovgu/featureide/fm/attributes/base/impl/ExtendedMultiFeatureModelFactory.java
@@ -71,7 +71,7 @@ public class ExtendedMultiFeatureModelFactory extends MultiFeatureModelFactory {
 
 	@Override
 	public ExtendedMultiFeature copyFeature(IFeatureModel featureModel, IFeature oldFeature) {
-		return (ExtendedMultiFeature) oldFeature.clone(featureModel, oldFeature.getStructure().clone(featureModel));
+		return (ExtendedMultiFeature) oldFeature.getStructure().clone(featureModel).getFeature();
 	}
 
 	@Override

--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/base/impl/DefaultFeatureModelFactory.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/base/impl/DefaultFeatureModelFactory.java
@@ -69,7 +69,7 @@ public class DefaultFeatureModelFactory implements IFeatureModelFactory {
 
 	@Override
 	public IFeature copyFeature(IFeatureModel featureModel, IFeature oldFeature) {
-		return oldFeature.clone(featureModel, oldFeature.getStructure().clone(featureModel));
+		return oldFeature.getStructure().clone(featureModel).getFeature();
 	}
 
 	@Override

--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/base/impl/MultiFeatureModelFactory.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/base/impl/MultiFeatureModelFactory.java
@@ -72,7 +72,7 @@ public class MultiFeatureModelFactory implements IFeatureModelFactory {
 
 	@Override
 	public MultiFeature copyFeature(IFeatureModel featureModel, IFeature oldFeature) {
-		return (MultiFeature) oldFeature.clone(featureModel, oldFeature.getStructure().clone(featureModel));
+		return (MultiFeature) oldFeature.getStructure().clone(featureModel).getFeature();
 	}
 
 	@Override

--- a/tests/de.ovgu.featureide.fm.core-test/src/de/ovgu/featureide/fm/core/base/CustomFeaturesCustomPropertiesTest.java
+++ b/tests/de.ovgu.featureide.fm.core-test/src/de/ovgu/featureide/fm/core/base/CustomFeaturesCustomPropertiesTest.java
@@ -86,7 +86,7 @@ public class CustomFeaturesCustomPropertiesTest {
 
 		@Override
 		public MyFeatureImplementation copyFeature(IFeatureModel featureModel, IFeature oldFeature) {
-			return (MyFeatureImplementation) oldFeature.clone(featureModel, oldFeature.getStructure().clone(featureModel));
+			return (MyFeatureImplementation) oldFeature.getStructure().clone(featureModel).getFeature();
 		}
 
 		@Override


### PR DESCRIPTION
Fixes #1206 and presumably other bugs related to editing a model after undoing a feature deletion.

copyFeature method implementation of all feature model factories, used for undoing feature deletions, previously left the feature model in a broken state, with duplicate feature instances for the same feature (one in the model's feature table, and one in the feature structure). This caused issues when further editing the model (such as feature renaming, see #1206).