### PR TITLE
Refactor classes to enable UVL as composers' feature model

### DIFF
--- a/plugins/de.ovgu.featureide.core/src/de/ovgu/featureide/core/CorePlugin.java
+++ b/plugins/de.ovgu.featureide.core/src/de/ovgu/featureide/core/CorePlugin.java
@@ -554,10 +554,10 @@ public class CorePlugin extends AbstractCorePlugin {
 	}
 
 	private static FeatureModelManager createFeatureModelFile(IProject project, IComposerExtensionClass composerClass) {
-		final Path modelPath = EclipseFileSystem.getPath(project.getFile("model.xml"));
+		final IFeatureModelFormat format = composerClass.getFeatureModelFormat();
+		final Path modelPath = EclipseFileSystem.getPath(project.getFile("model." + format.getSuffix()));
 
 		if (!Files.exists(modelPath)) {
-			final IFeatureModelFormat format = composerClass.getFeatureModelFormat();
 			IFeatureModelFactory factory;
 			try {
 				factory = FMFactoryManager.getInstance().getFactory(modelPath, format);

--- a/plugins/de.ovgu.featureide.core/src/de/ovgu/featureide/core/internal/FeatureProject.java
+++ b/plugins/de.ovgu.featureide.core/src/de/ovgu/featureide/core/internal/FeatureProject.java
@@ -339,6 +339,8 @@ public class FeatureProject extends BuilderMarkerHandler implements IFeatureProj
 
 		if (project.getFile("mpl.velvet").exists()) {
 			modelFile = new ModelMarkerHandler<>(project.getFile("mpl.velvet"));
+		} else if (project.getFile("model.uvl").exists()) {
+			modelFile = new ModelMarkerHandler<>(project.getFile("model.uvl"));
 		} else {
 			modelFile = new ModelMarkerHandler<>(project.getFile("model.xml"));
 		}

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/configuration/ConfigurationEditor.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/configuration/ConfigurationEditor.java
@@ -241,7 +241,9 @@ public class ConfigurationEditor extends MultiPageEditorPart implements GUIDefau
 			// final IContainer parentFolder = file.getParent();
 			// mappingModel = parentFolder != null && "InterfaceMapping".equals(parentFolder.getName());
 		} else {
-			res = project.findMember("model.xml");
+			// try to find UVL model first before resort to XML
+			final String filename = project.getFile("model.uvl").exists() ? "model.uvl" : "model.xml";
+			res = project.findMember(filename);
 		}
 
 		File modelFile = null;

--- a/plugins/de.ovgu.featureide.ui/src/de/ovgu/featureide/ui/wizards/NewFeatureProjectWizard.java
+++ b/plugins/de.ovgu.featureide.ui/src/de/ovgu/featureide/ui/wizards/NewFeatureProjectWizard.java
@@ -168,8 +168,9 @@ public class NewFeatureProjectWizard extends BasicNewProjectResourceWizard {
 					final IProject newProject = getNewProject();
 					wizardExtension.enhanceProject(newProject, page.getCompositionTool().getId(), page.getSourcePath(), page.getConfigPath(),
 							page.getBuildPath(), page.sourcePath.isEnabled(), page.buildPath.isEnabled());
-					// open editor
-					UIPlugin.getDefault().openEditor(FeatureModelEditor.ID, newProject.getFile("model.xml"));
+					// open editor. try to search uvl format first before xml.
+					final String modelFile = newProject.getFile("model.uvl").exists() ? "model.uvl" : "model.xml";
+					UIPlugin.getDefault().openEditor(FeatureModelEditor.ID, newProject.getFile(modelFile));
 				} catch (final CoreException e) {
 					UIPlugin.getDefault().logError(e);
 				}


### PR DESCRIPTION
Dear FeatureIDE's developer team.

My name is Samuel Tupa Febrian from Reliable Software Engineering (RSE) Lab at University of Indonesia. I'm currently using FeatureIDE to develop my research about integrating FeatureIDE with one of our lab's research, WinVMJ Framework. It is a framework to develop software using SPLE and Delta-Oriented Programming (DOP) approaches as well as supporting MPL development. The goal of this research is to develop WinVMJ as one of FeatureIDE composers to compose a running product.

During my research, I tried to use the UVL feature model HelloWorld-Antenna example project and after making sure UVL model is the sole feature model on the project, I found a problem when I change the UVL model like this:

![image](https://user-images.githubusercontent.com/31442930/157371542-70ce61a4-ed63-49e1-823b-7bbaea0a46bd.png)

It seems that the configuration always reverts back to refer to the original model (XML one).

Even though it'll refer to the UVL model if I close and re-open it, it'll refer back to the UVL model, but its constraint highlight seems to refer to the original one.

![image](https://user-images.githubusercontent.com/31442930/157371573-4ba5befb-8ec9-45e2-98fa-857158fc9ba9.png)

As seen in the picture above, the "Ngeng" feature isn't highlighted, even though it's one of the `Feature`'s alternatives. This issue can be resolved by restarting eclipse, but even then the configuration is still deemed invalid.

![image](https://user-images.githubusercontent.com/31442930/157371623-3a1216b2-9e38-4d48-8e1b-320ca6cfbbc9.png)

I tried to fix the problem by refactoring some classes on FeatureIDE source code and after consulting with Mr. Chico Sundermann as well as my supervisor, I would like to share this solution as a contribution to FeatureIDE. Perhaps the UVL model can be used as the default feature model format.

Here are explanations about the refactored classes

1. `CorePlugin`: I refactored the `modelPath` assignment so it will check the composer's feature model format to decide the model's file extension. This will enable the use of UVLFeatureModelFormat as the composer's feature model format if needed.

![image](https://user-images.githubusercontent.com/31442930/157372181-0ef2ed07-572a-4df1-8563-be363df16dc3.png)

To avoid conflict with existing composers, I opted to retain the model's name, so it can still create `model.xml`.

2. `FeatureProject`: I refactored the conditional statement to implement an else if to check the `uvl` format. As a result, the UVL can be fully used on the FeatureIDE project with FeatureHouse and Antenna composer. I'm sorry that I cannot try the rest.

3. `ConfigurationEditor`: I refactored it so the editor will try to find the `model.uvl` if it exists. This way, whenever I replace the model.xml with `model.uvl`, the configuration will no longer need to manually select the feature model.

4. `NewFeatureProjectWizard`: I refactored the `modelFile` assignment to enable `model.uvl` to be opened if it's the created model file on `CorePlugin.createFeatureModelFile`. This way, the UVL can be opened immediately after creating a new FeatureIDE Project.

Feel free to test my solution and refactor it even further if necessary. I hope my solution can help the FeatureIDE development in the future.

Best Regards,

Samuel Tupa Febrian