### PR TITLE
Fixes #1353

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/DeleteSubmodelAction.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/actions/DeleteSubmodelAction.java
@@ -91,7 +91,7 @@ public class DeleteSubmodelAction extends MultipleSelectionAction implements Act
 
 		final Optional<String> dialogReturnLabel = DeleteDialogVerifier.checkForDialog(featuresToDelete);
 
-		if (dialogReturnLabel.filter("Cancel"::equals).isPresent()) {
+		if (dialogReturnLabel.filter("Cancel"::equals).isEmpty()) {
 			FeatureModelOperationWrapper.run(new DeleteSubmodelOperation(viewer, featureModelManager));
 		}
 


### PR DESCRIPTION
When pressing 'Cancel' when deleting a submodel, it now really is cancelled.