### PR TITLE
PartialFeatureProjectJob: Fix path separator in configuration loading for Windows

### DIFF
--- a/plugins/de.ovgu.featureide.core/src/de/ovgu/featureide/core/job/PartialFeatureProjectJob.java
+++ b/plugins/de.ovgu.featureide.core/src/de/ovgu/featureide/core/job/PartialFeatureProjectJob.java
@@ -68,7 +68,7 @@ public class PartialFeatureProjectJob implements LongRunningMethod<Boolean> {
 		IFeatureProject newFeatureProject = CorePlugin.getFeatureProject(newProject);
 		while ((newFeatureProject = CorePlugin.getFeatureProject(newProject)) == null) {}
 		final Configuration config =
-			baseProject.loadConfiguration(Paths.get(ResourcesPlugin.getWorkspace().getRoot().getLocation().toString() + file.getFullPath()));
+			baseProject.loadConfiguration(Paths.get(file.getLocation().toOSString()));
 
 		LongRunningWrapper.runMethod(new PartialFeatureProjectBuilder(newFeatureProject, config));
 		return null;


### PR DESCRIPTION
#### Prerequisitives
* **Eclipse Version:**  `2023-12 (4.30.0)`
* **FeatureIDE-Version:**  `3.11.1.202409252258`
* **Operating system:** `Windows 11`
* **Java runtime used to run eclipse:** `Java 17`
* **FeatureIDE Composer:** -
* **Git branch/Commit-ID:**  [release3.11.1](https://github.com/FeatureIDE/FeatureIDE/tree/release3.11.1)
* **Java compiler used to build the FeatureIDE plugin:** -

### Pull request description

Hello, FeatureIDE team.

When attempting to create a subset SPL from a partial configuration (Right click config file -> FeatureIDE -> Derive Partial Feature Project with this Configuration), I encountered the following error:

```
Exception caught: Cannot invoke "de.ovgu.featureide.fm.core.configuration.Configuration.getUnselectedFeatureNames()" because "this.config" is null
java.lang.NullPointerException: Cannot invoke "de.ovgu.featureide.fm.core.configuration.Configuration.getUnselectedFeatureNames()" because "this.config" is null
	at de.ovgu.featureide.core.builder.PartialFeatureProjectBuilder.execute(PartialFeatureProjectBuilder.java:88)
	at de.ovgu.featureide.core.builder.PartialFeatureProjectBuilder.execute(PartialFeatureProjectBuilder.java:1)
	at de.ovgu.featureide.fm.core.job.LongRunningWrapper.runMethod(LongRunningWrapper.java:53)
	at de.ovgu.featureide.fm.core.job.LongRunningWrapper.runMethod(LongRunningWrapper.java:41)
	at de.ovgu.featureide.core.job.PartialFeatureProjectJob.execute(PartialFeatureProjectJob.java:77)
	at de.ovgu.featureide.core.job.PartialFeatureProjectJob.execute(PartialFeatureProjectJob.java:1)
	at de.ovgu.featureide.fm.core.job.Executer.execute(Executer.java:44)
	at de.ovgu.featureide.fm.core.job.LongRunningJob.work(LongRunningJob.java:48)
	at de.ovgu.featureide.fm.core.job.AbstractJob.run(AbstractJob.java:122)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:63)
```

After some debugging, It turns out `execute()` method of `PartialFeatureProjectJob` class it is trying to load the config based on the following path string: `C:/Users/path/to/config.xml`. Windows uses backslashes for path separator, so it is supposed to be `C:\Users\path\to\config.xml`

I've make a change in the `execute()` method to use `file.getLocation().toOSString()`, which lets Eclipse handle the path resolution and OS-specific formatting rather than trying to construct it manually. This fixes the null configuration issue in `PartialFeatureProjectBuilder` when running on Windows.

Testing Done:
- Tested on Windows 11 with Eclipse 2023-12 (4.30.0)
- Verified configuration loading works correctly in partial feature project creation
- Confirmed path resolution works with different projects

Please let me know if you would like me to make any adjustments to this change. Thank you in advance.