### PR TITLE
Fix SWT resource leaks in Advanced Configuration Editor UI

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/configuration/AdvancedConfigurationPage.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/configuration/AdvancedConfigurationPage.java
@@ -75,37 +75,57 @@ public class AdvancedConfigurationPage extends ConfigurationTreeEditorPage imple
 		final FeatureColor color = FeatureColorManager.getColor(feature);
 		final String imageString = image1.toString() + image2.toString() + (color != null ? color.getColorName() : "");
 		Image combinedImage = combinedImages.get(imageString);
+
 		if (combinedImage == null) {
 			final int distance = 4;
 			final int colorWidth = 24;
 			final int colorHeight = 12;
 
-			final ImageData imageData1 = image1.getImageData();
-			final ImageData imageData2 = image2.getImageData();
-			final Image image =
-				new Image(Display.getCurrent(), imageData2.width + distance + imageData1.width + distance + colorWidth + distance, imageData1.height);
-			final ImageData id = image.getImageData();
-			id.alpha = 0;
-			combinedImage = new Image(Display.getCurrent(), id);
-			final GC gc = new GC(combinedImage);
+			Image tempImage = null;
+			GC gc = null;
+			try {
+				final ImageData imageData1 = image1.getImageData();
+				final ImageData imageData2 = image2.getImageData();
 
-			gc.drawImage(image2, 0, 0, imageData2.width, imageData2.height, 0, 0, imageData2.width, imageData2.height);
-			gc.drawImage(image1, 0, 0, imageData1.width, imageData1.height, imageData2.width + distance, 0, imageData1.width, imageData1.height);
-			if (color != FeatureColor.NO_COLOR) {
-				gc.setBackground(new Color(Display.getCurrent(), ColorPalette.getRGB(color.getValue(), 0.5f)));
-				gc.fillRoundRectangle(imageData2.width + distance + imageData1.width + distance, (imageData1.height - colorHeight) / 2, colorWidth, colorHeight,
-						colorHeight, colorHeight);
-			} else {
-				gc.setForeground(FMPropertyManager.getLegendBorderColor());
-				gc.drawRoundRectangle(imageData2.width + distance + imageData1.width + distance, (imageData1.height - colorHeight) / 2, colorWidth, colorHeight,
-						colorHeight, colorHeight);
-			}
+				tempImage =
+					new Image(Display.getCurrent(), imageData2.width + distance + imageData1.width + distance + colorWidth + distance, imageData1.height);
+				final ImageData id = tempImage.getImageData();
+				id.alpha = 0;
 
-			image.dispose();
-			if (feature.getStructure().isRoot()) {
-				image1.dispose();
+				combinedImage = new Image(Display.getCurrent(), id);
+				gc = new GC(combinedImage);
+
+				gc.drawImage(image2, 0, 0, imageData2.width, imageData2.height, 0, 0, imageData2.width, imageData2.height);
+				gc.drawImage(image1, 0, 0, imageData1.width, imageData1.height, imageData2.width + distance, 0, imageData1.width, imageData1.height);
+
+				if (color != FeatureColor.NO_COLOR) {
+					final Color bgColor = new Color(null, ColorPalette.getRGB(color.getValue(), 0.5f));
+					try {
+						gc.setBackground(bgColor);
+						gc.fillRoundRectangle(imageData2.width + distance + imageData1.width + distance, (imageData1.height - colorHeight) / 2, colorWidth,
+								colorHeight, colorHeight, colorHeight);
+					} finally {
+						bgColor.dispose();
+					}
+				} else {
+					gc.setForeground(FMPropertyManager.getLegendBorderColor());
+					gc.drawRoundRectangle(imageData2.width + distance + imageData1.width + distance, (imageData1.height - colorHeight) / 2, colorWidth,
+							colorHeight, colorHeight, colorHeight);
+				}
+
+				combinedImages.put(imageString, combinedImage);
+
+			} finally {
+				if (gc != null) {
+					gc.dispose();
+				}
+				if (tempImage != null) {
+					tempImage.dispose();
+				}
+				if (feature.getStructure().isRoot() && (image1 != null) && !image1.isDisposed()) {
+					image1.dispose();
+				}
 			}
-			combinedImages.put(imageString, combinedImage);
 		}
 
 		return combinedImage;

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/configuration/ConfigurationPage.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/configuration/ConfigurationPage.java
@@ -173,28 +173,44 @@ public class ConfigurationPage extends ConfigurationTreeEditorPage {
 		final FeatureColor color = FeatureColorManager.getColor(feature);
 		final String imageString = color != null ? color.getColorName() : "";
 		Image combinedImage = combinedImages.get(imageString);
+
 		if (combinedImage == null) {
 			final int distance = 4;
 			final int colorWidth = 24;
 			final int colorHeight = 12;
 
-			final Image image = new Image(Display.getCurrent(), distance + colorWidth + distance, colorHeight + 2);
-			final ImageData id = image.getImageData();
-			id.alpha = 0;
-			combinedImage = new Image(Display.getCurrent(), id);
+			Image tempImage = null;
+			GC gc = null;
+			try {
+				tempImage = new Image(Display.getCurrent(), distance + colorWidth + distance, colorHeight + 2);
+				final ImageData id = tempImage.getImageData();
+				id.alpha = 0;
 
-			final GC gc = new GC(combinedImage);
+				combinedImage = new Image(Display.getCurrent(), id);
+				gc = new GC(combinedImage);
 
-			if (color != FeatureColor.NO_COLOR) {
-				gc.setBackground(new Color(null, ColorPalette.getRGB(color.getValue(), 0.5f)));
-				gc.fillRoundRectangle(distance, 1, colorWidth, colorHeight, colorHeight, colorHeight);
-			} else {
-				gc.setForeground(FMPropertyManager.getLegendBorderColor());
-				gc.drawRoundRectangle(distance, 1, colorWidth, colorHeight, colorHeight, colorHeight);
+				if (color != FeatureColor.NO_COLOR) {
+					final Color bgColor = new Color(null, ColorPalette.getRGB(color.getValue(), 0.5f));
+					try {
+						gc.setBackground(bgColor);
+						gc.fillRoundRectangle(distance, 1, colorWidth, colorHeight, colorHeight, colorHeight);
+					} finally {
+						bgColor.dispose();
+					}
+				} else {
+					gc.setForeground(FMPropertyManager.getLegendBorderColor());
+					gc.drawRoundRectangle(distance, 1, colorWidth, colorHeight, colorHeight, colorHeight);
+				}
+
+				combinedImages.put(imageString, combinedImage);
+			} finally {
+				if (gc != null) {
+					gc.dispose();
+				}
+				if (tempImage != null) {
+					tempImage.dispose();
+				}
 			}
-			combinedImages.put(imageString, combinedImage);
-
-			image.dispose();
 		}
 
 		return combinedImage;


### PR DESCRIPTION
#### Prerequisitives
* **Eclipse Version:**  `2023-12 (4.30.0)`
* **FeatureIDE-Version:**  `3.11.1.202409252258`
* **Operating system:** `Windows 11`
* **Java runtime used to run eclipse:** `Java 17`
* **FeatureIDE Composer:** -
* **Git branch/Commit-ID:**  [release3.11.1](https://github.com/FeatureIDE/FeatureIDE/tree/release3.11.1)
* **Java compiler used to build the FeatureIDE plugin:** -

### Pull request description

Hello, FeatureIDE team.

When opening the Advanced Configuration editor on a configuration file of a FeatureIDE project, the UI icons are not displayed properly, as illustrated below.

![image](https://github.com/user-attachments/assets/8129be6e-d1c3-42a7-967e-ef7a7d02b352)

Checking the eclipse logs, it appears there may have been issues in the image handling code within `FeatureDiagramEditor.java`.
```
!ENTRY org.eclipse.ui.ide 4 4 2024-10-14 15:30:10.865
!MESSAGE Not properly disposed SWT resource
!STACK 0
java.lang.Error: SWT Resource was not properly disposed
	at org.eclipse.swt.graphics.Resource.initNonDisposeTracking(Resource.java:172)
	at org.eclipse.swt.graphics.Resource.<init>(Resource.java:120)
	at org.eclipse.swt.graphics.Image.<init>(Image.java:668)
	at org.eclipse.jface.resource.URLImageDescriptor.createImage(URLImageDescriptor.java:300)
	at org.eclipse.jface.resource.ImageDescriptor.createImage(ImageDescriptor.java:290)
	at org.eclipse.jface.resource.ImageDescriptor.createImage(ImageDescriptor.java:268)
	at de.ovgu.featureide.fm.ui.editors.ToolBarMenuManager.<init>(ToolBarMenuManager.java:53)
	at de.ovgu.featureide.fm.ui.editors.FeatureDiagramEditor.createLayoutMenuManager(FeatureDiagramEditor.java:1259)
	at de.ovgu.featureide.fm.ui.editors.FeatureDiagramEditor.createPartControl(FeatureDiagramEditor.java:441)
	at org.eclipse.ui.part.MultiPageEditorPart.addPage(MultiPageEditorPart.java:227)
	at org.eclipse.ui.part.MultiPageEditorPart.addPage(MultiPageEditorPart.java:203)
	at de.ovgu.featureide.fm.ui.editors.FeatureModelEditor.addPage(FeatureModelEditor.java:450)
	at de.ovgu.featureide.fm.ui.editors.FeatureModelEditor.createPages(FeatureModelEditor.java:418)
	at org.eclipse.ui.part.MultiPageEditorPart.createPartControl(MultiPageEditorPart.java:333)
```

After looking at the `ConfigurationPage` and `AdvancedConfigurationPage` classes of the `de.ovgu.featureide.fm.ui` plugin, there are potential SWT resource leak issues in both classes occuring in the `getImage()` methods where several resources are created but not all are properly disposed:
- GC objects are created but never disposed
- Color objects created but never disposed
- Some temporary Image objects may leak

I propose a fix to handle the SWT resources. I added proper resource management using try-finally blocks and explicitly dispose objects after use. 

The result is the icons are properly displayed on the editor again.

![image](https://github.com/user-attachments/assets/4cfa8838-aef4-4b9e-841c-cdf5581bd8e3)

Please let me know if you would like me to make any adjustments to this change. Thank you in advance.

### Related Commit
[160ef47](https://github.com/FeatureIDE/FeatureIDE/commit/160ef478773c21dc7ed9b5fda3723b14eae14fb3): `Fixes UI problem on MacOS.`