### PR TITLE
Fixes #1495

### DIFF
--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
@@ -201,11 +201,30 @@ public class UVLFeatureModelFormat extends AFeatureModelFormat {
 			fm.addAttribute(uvlFeature.getReferenceFromSpecificSubmodel(""), NS_ATTRIBUTE_FEATURE, uvlFeature.getRelatedImport().getNamespace());
 		}
 
-		for (final Group group : uvlFeature.getChildren()) {
-			parseGroup(fm, group, feature);
+		if (uvlFeature.getChildren().size() == 1) {
+			parseGroup(fm, uvlFeature.getChildren().get(0), feature);
+		} else {
+			feature.getStructure().setAnd();
+			for (final Group group : uvlFeature.getChildren()) {
+				final MultiFeature groupParent = factory.createFeature(fm, getGroupFeatureName(fm, feature, group));
+				fm.addFeature(groupParent);
+				groupParent.getStructure().setAbstract(true);
+				groupParent.getStructure().setMandatory(true);
+				feature.getStructure().addChild(groupParent.getStructure());
+				parseGroup(fm, group, groupParent);
+			}
 		}
 
 		return feature;
+	}
+
+	private String getGroupFeatureName(IFeatureModel featureModel, IFeature parentFeature, Group group) {
+		int index = 0;
+		String name = parentFeature.getName() + "_" + group.GROUPTYPE.toString() + "_" + index;
+		while (featureModel.getFeature(name) != null) {
+			name = group.GROUPTYPE.toString() + "_" + ++index;
+		}
+		return name;
 	}
 
 	private void parseGroup(MultiFeatureModel fm, Group uvlGroup, IFeature parentFeature) {

--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
@@ -222,7 +222,7 @@ public class UVLFeatureModelFormat extends AFeatureModelFormat {
 		int index = 0;
 		String name = parentFeature.getName() + "_" + group.GROUPTYPE.toString() + "_" + index;
 		while (featureModel.getFeature(name) != null) {
-			name = group.GROUPTYPE.toString() + "_" + ++index;
+			name = parentFeature.getName() + "_" + group.GROUPTYPE.toString() + "_" + ++index;
 		}
 		return name;
 	}


### PR DESCRIPTION
Uvl features with multiple child groups are now correctly resolved

```
features
        root_1_1
            or
                    "firstAlternativeFeature-1-1"
                    "secondAlternativeFeature-1-1"
                    "thirdAlternativeFeature-1-1"
            alternative
                    "firstOrFeature-1-1"
                    "secondOrFeature-1-1"
                    "thirdOrFeature-1-1"
            mandatory
            		"mandatoryFeature-1-1"
    	    optional
    				"optionalFeature-1-1"
```
The shown UVL model initially produced this feature model:
![Screenshot from 2025-01-04 10-04-00](https://github.com/user-attachments/assets/1f39263e-8672-4b3d-912d-8bc52b3cf850)

With the changes the following feature model is produced:
![Screenshot from 2025-01-04 11-43-37](https://github.com/user-attachments/assets/f416a37d-603d-4297-adaa-9e825c63c0ec)
