### PR TITLE
Use the new GEF-classic API instead of the removed and deprecated one

### DIFF
--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureUIHelper.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureUIHelper.java
@@ -30,7 +30,7 @@ import java.util.Map;
 import org.eclipse.draw2d.geometry.Point;
 import org.eclipse.draw2d.geometry.Rectangle;
 import org.eclipse.gef.EditPartViewer;
-import org.eclipse.gef.editparts.ZoomListener;
+import org.eclipse.draw2d.zoom.ZoomListener;
 import org.eclipse.gef.editparts.ZoomManager;
 
 import de.ovgu.featureide.fm.core.base.FeatureUtils;
@@ -48,6 +48,7 @@ import de.ovgu.featureide.fm.ui.editors.featuremodel.layouts.FeatureModelLayout;
  * @author Christian Kaestner
  * @author Martha Nyerembe
  * @author Lukas Vogt
+ * @author Malte Grave
  */
 public class FeatureUIHelper {
 

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/commands/renaming/FeatureLabelEditManager.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/featuremodel/commands/renaming/FeatureLabelEditManager.java
@@ -55,13 +55,14 @@ import de.ovgu.featureide.fm.ui.editors.featuremodel.editparts.FeatureEditPart;
  * @author Florian Proksch
  * @author Stefan Krueger
  * @author Marcus Pinnecke
+ * @author Malte Grave
  */
 public class FeatureLabelEditManager extends DirectEditManager implements GUIDefaults {
 
 	private final IManager<IFeatureModel> featureModelManager;
 	private final FeatureEditPart editPart;
 
-	public FeatureLabelEditManager(FeatureEditPart editPart, Class<?> editorType, FeatureCellEditorLocator locator,
+	public FeatureLabelEditManager(FeatureEditPart editPart, Class<? extends CellEditor> editorType, FeatureCellEditorLocator locator,
 			IManager<IFeatureModel> featureModelManager) {
 		super(editPart, editorType, locator);
 		this.featureModelManager = featureModelManager;

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,8 @@
 	<packaging>pom</packaging>
 
 	<properties>
-		<tycho-version>1.1.0</tycho-version>
-		<tycho-extras-version>1.1.0</tycho-extras-version>
+		<tycho-version>4.0.10</tycho-version>
+		<tycho-extras-version>4.0.10</tycho-extras-version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
@@ -270,8 +270,8 @@
 
 	<repositories>
 		<repository>
-			<id>oxygen</id>
-			<url>http://download.eclipse.org/releases/oxygen</url>
+			<id>2024-12</id>
+			<url>http://download.eclipse.org/releases/2024-12</url>
 			<layout>p2</layout>
 		</repository>
 	</repositories>


### PR DESCRIPTION
As discussed in the meeting, here is the pull request which uses the new gef-classic API.

The gef-classic API is used by the graphical model editor.
The corresponding commit, where the API changes were introduced, can be found at: https://github.com/eclipse-gef/gef-classic/commit/a428caf276b14847bc86b83beb7603e9d6ff6291

AFAIK, this change is not introduced in the 2024-12 platform, but it will in the 2025-03 so with the next Eclipse in March, FeatureIDE will break for sure on the new Eclipse Platform. The reason why this breaks for us is, that we are on the RC channel of Eclipse 4diac, which uses the master-branch of gef-classic.

Note, I have updated the Eclipse mirror as well in this PR, so test with caution. We heavily depend on the newest version due to version conflicts otherwise.

My guess is that the change with the version is not yet necessary but as I said please test this with and without the version bump and report back. I will change the pom.xml than accordingly.