### PR TITLE
Prevent graphical editor for UVL feature cardinalities

### DIFF
--- a/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
+++ b/plugins/de.ovgu.featureide.fm.core/src/de/ovgu/featureide/fm/core/io/uvl/UVLFeatureModelFormat.java
@@ -82,6 +82,8 @@ import de.vill.model.constraint.ParenthesisConstraint;
  */
 public class UVLFeatureModelFormat extends AFeatureModelFormat {
 
+	public static final String UNSUPPORTED_FEATURE_CARDINALITY = "Feature cardinalities are not supported by FeatureIDE.";
+
 	public static final String ID = PluginID.PLUGIN_ID + ".format.fm." + UVLFeatureModelFormat.class.getSimpleName();
 	public static final String FILE_EXTENSION = "uvl";
 
@@ -178,8 +180,25 @@ public class UVLFeatureModelFormat extends AFeatureModelFormat {
 		// final Map<String, UsedModel> externalModels = fm.getExternalModels();
 	}
 
+	public static boolean containsUnsupportedFeatureCardinality(ProblemList problems) {
+		for (final Problem problem : problems) {
+			if ((problem.getMessage() != null) && problem.getMessage().startsWith(UNSUPPORTED_FEATURE_CARDINALITY)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private boolean hasFeatureCardinality(Feature feature) {
+		return (feature.getLowerBound() != null) || (feature.getUpperBound() != null);
+	}
+
 	private IFeature parseFeature(MultiFeatureModel fm, Feature uvlFeature, IFeature parentFeature) {
 		final MultiFeature feature = factory.createFeature(fm, uvlFeature.getReferenceFromSpecificSubmodel(""));
+		if (hasFeatureCardinality(uvlFeature)) {
+			pl.add(new Problem(String.format("%s Feature %s uses cardinality [%s..%s].", UNSUPPORTED_FEATURE_CARDINALITY,
+					uvlFeature.getReferenceFromSpecificSubmodel(""), uvlFeature.getLowerBound(), uvlFeature.getUpperBound()), 0, Severity.WARNING));
+		}
 		fm.addFeature(feature);
 
 		final Attribute<?> featureDescription = uvlFeature.getAttributes().get(FEATURE_DESCRIPTION_ATTRIBUTE_NAME);

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureModelEditor.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureModelEditor.java
@@ -95,6 +95,7 @@ import de.ovgu.featureide.fm.core.io.EclipseFileSystem;
 import de.ovgu.featureide.fm.core.io.IPersistentFormat;
 import de.ovgu.featureide.fm.core.io.Problem;
 import de.ovgu.featureide.fm.core.io.ProblemList;
+import de.ovgu.featureide.fm.core.io.uvl.UVLFeatureModelFormat;
 import de.ovgu.featureide.fm.core.io.manager.FeatureModelManager;
 import de.ovgu.featureide.fm.ui.FMUIPlugin;
 import de.ovgu.featureide.fm.ui.GraphicsExporter;
@@ -428,8 +429,9 @@ public class FeatureModelEditor extends MultiPageEditorPart implements IEventLis
 			currentPageIndex = 0;
 			// if there are errors in the model file, go to source page
 			final ProblemList problems = checkModel(textEditor.getCurrentContent());
-			if (problems.containsError()) {
+			if (problems.containsError() || UVLFeatureModelFormat.containsUnsupportedFeatureCardinality(problems)) {
 				createModelFileMarkers(problems);
+				currentPageIndex = textEditor.getIndex();
 				setActivePage(textEditor.getIndex());
 			} else {
 				diagramEditor.getViewer().getControl().getDisplay().asyncExec(new Runnable() {
@@ -619,6 +621,10 @@ public class FeatureModelEditor extends MultiPageEditorPart implements IEventLis
 				FMCorePlugin.getDefault().logError(e);
 			}
 		}
+	}
+
+	boolean isDiagramEditorPage(int pageIndex) {
+		return pageIndex == getDiagramEditorIndex();
 	}
 
 	private int getDiagramEditorIndex() {

--- a/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureModelTextEditorPage.java
+++ b/plugins/de.ovgu.featureide.fm.ui/src/de/ovgu/featureide/fm/ui/editors/FeatureModelTextEditorPage.java
@@ -40,6 +40,7 @@ import org.eclipse.ui.texteditor.IDocumentProvider;
 import de.ovgu.featureide.fm.core.base.event.FeatureIDEEvent;
 import de.ovgu.featureide.fm.core.io.Problem;
 import de.ovgu.featureide.fm.core.io.ProblemList;
+import de.ovgu.featureide.fm.core.io.uvl.UVLFeatureModelFormat;
 import de.ovgu.featureide.fm.core.io.manager.FeatureModelManager;
 import de.ovgu.featureide.fm.ui.FMUIPlugin;
 import de.ovgu.featureide.fm.ui.editors.featuremodel.operations.FeatureModelOperationWrapper;
@@ -155,6 +156,9 @@ public class FeatureModelTextEditorPage extends TextEditor implements IFeatureMo
 			createMarkers(problems);
 		} else {
 			deleteMarkers(getDocumentProvider().getAnnotationModel(getEditorInput()));
+		}
+		if (featureModelEditor.isDiagramEditorPage(newPage) && UVLFeatureModelFormat.containsUnsupportedFeatureCardinality(problems)) {
+			return false;
 		}
 		return !problems.containsError();
 	}


### PR DESCRIPTION
Fixes #1289.

Feature cardinalities in UVL are parsed by the UVL parser, but FeatureIDE's graphical editor does not support them. Previously, affected UVL models could be opened in the graphical editor and the cardinality information could be lost when saving.

This change:
- adds a warning when UVL feature cardinalities are encountered
- keeps affected models in the source editor when opened
- blocks switching to the graphical editor for affected models

Tested:
- Verified with UVLModelFactory that `Child cardinality [1..3]` sets lowerBound=1 and upperBound=3 on the parsed Feature.
- `git diff --check`

Not run:
- Maven build, because the checked-out repository has a parent POM version mismatch: the root POM is `3.11.1-SNAPSHOT`, while plugin POMs expect `de.ovgu.featureide.root:3.12.0-SNAPSHOT`.
- Manual Eclipse/FeatureIDE UI test, because the local Eclipse-based runtime setup was not available.